### PR TITLE
Regenerate recording rules

### DIFF
--- a/autometrics-cli/src/sloth.rs
+++ b/autometrics-cli/src/sloth.rs
@@ -48,10 +48,10 @@ slos:
 }
 
 fn generate_success_rate_slo(objective: &Decimal) -> String {
-    let objective_fraction = objective / Decimal::from(100);
-    let objective_fraction_no_decimal = objective_fraction.to_string().replace(".", "");
+    let objective_fraction = (objective / Decimal::from(100)).normalize();
+    let objective_no_decimal = objective.to_string().replace(".", "");
 
-    format!("  - name: success-rate-{objective_fraction_no_decimal}
+    format!("  - name: success-rate-{objective_no_decimal}
     objective: {objective}
     description: Common SLO based on function success rates
     sli:
@@ -74,10 +74,10 @@ fn generate_success_rate_slo(objective: &Decimal) -> String {
 }
 
 fn generate_latency_slo(objective: &Decimal) -> String {
-    let objective_fraction = objective / Decimal::from(100);
-    let objective_fraction_no_decimal = objective_fraction.to_string().replace(".", "");
+    let objective_fraction = (objective / Decimal::from(100)).normalize();
+    let objective_no_decimal = objective.to_string().replace(".", "");
 
-    format!("  - name: latency-{objective_fraction_no_decimal}
+    format!("  - name: latency-{objective_no_decimal}
     objective: {objective}
     description: Common SLO based on function latency
     sli:

--- a/autometrics.rules.yml
+++ b/autometrics.rules.yml
@@ -4,5535 +4,1591 @@
 # DO NOT EDIT.
 
 groups:
-- name: sloth-slo-sli-recordings-autometrics-success-rate-1-095
+- name: sloth-slo-sli-recordings-autometrics-success-rate-90
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[5m])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[5m])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[30m])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[30m])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[1h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[1h])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[2h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[2h])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[6h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[6h])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[1d])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[1d])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="95",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9",result="error"}[3d])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="95"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.9"}[3d])))
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"}[30d])
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-90
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-1-095
+- name: sloth-slo-meta-recordings-autometrics-success-rate-90
+  rules:
+  - record: slo:objective:ratio
+    expr: vector(0.9)
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+  - record: slo:error_budget:ratio
+    expr: vector(1-0.9)
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+  - record: slo:time_period:days
+    expr: vector(30)
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+  - record: slo:current_burn_rate:ratio
+    expr: |
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"}
+      / on(sloth_id, sloth_slo, sloth_service) group_left
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"}
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+  - record: slo:period_burn_rate:ratio
+    expr: |
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"}
+      / on(sloth_id, sloth_slo, sloth_service) group_left
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"}
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+  - record: slo:period_error_budget_remaining:ratio
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-90", sloth_service="autometrics",
+      sloth_slo="success-rate-90"}
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+  - record: sloth_slo_info
+    expr: vector(1)
+    labels:
+      sloth_id: autometrics-success-rate-90
+      sloth_mode: cli-gen-prom
+      sloth_objective: "90"
+      sloth_service: autometrics
+      sloth_slo: success-rate-90
+      sloth_spec: prometheus/v1
+      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
+- name: sloth-slo-alerts-autometrics-success-rate-90
+  rules:
+  - alert: High Error Rate SLO - 90%
+    expr: |
+      (
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (14.4 * 0.1)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (14.4 * 0.1)) without (sloth_window)
+      )
+      or
+      (
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (6 * 0.1)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (6 * 0.1)) without (sloth_window)
+      )
+    labels:
+      category: success-rate
+      severity: page
+      sloth_severity: page
+    annotations:
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
+      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
+        burn rate is too fast.
+  - alert: High Error Rate SLO - 90%
+    expr: |
+      (
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (3 * 0.1)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (3 * 0.1)) without (sloth_window)
+      )
+      or
+      (
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (1 * 0.1)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-90", sloth_service="autometrics", sloth_slo="success-rate-90"} > (1 * 0.1)) without (sloth_window)
+      )
+    labels:
+      category: success-rate
+      severity: ticket
+      sloth_severity: ticket
+    annotations:
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
+      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
+        burn rate is too fast.
+- name: sloth-slo-sli-recordings-autometrics-success-rate-95
+  rules:
+  - record: slo:sli_error:ratio_rate5m
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[5m])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[5m])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 5m
+  - record: slo:sli_error:ratio_rate30m
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[30m])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[30m])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 30m
+  - record: slo:sli_error:ratio_rate1h
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[1h])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[1h])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 1h
+  - record: slo:sli_error:ratio_rate2h
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[2h])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[2h])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 2h
+  - record: slo:sli_error:ratio_rate6h
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[6h])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[6h])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 6h
+  - record: slo:sli_error:ratio_rate1d
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[1d])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[1d])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 1d
+  - record: slo:sli_error:ratio_rate3d
+    expr: |
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95",result="error"}[3d])))
+      /
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.95"}[3d])))
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 3d
+  - record: slo:sli_error:ratio_rate30d
+    expr: |
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"}[30d])
+      / ignoring (sloth_window)
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"}[30d])
+    labels:
+      sloth_id: autometrics-success-rate-95
+      sloth_service: autometrics
+      sloth_slo: success-rate-95
+      sloth_window: 30d
+- name: sloth-slo-meta-recordings-autometrics-success-rate-95
   rules:
   - record: slo:objective:ratio
     expr: vector(0.95)
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
   - record: slo:error_budget:ratio
     expr: vector(1-0.95)
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"}
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"}
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"}
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"}
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-1-095",
-      sloth_service="autometrics", sloth_slo="success-rate-1-095"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-95", sloth_service="autometrics",
+      sloth_slo="success-rate-95"}
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-095
+      sloth_id: autometrics-success-rate-95
       sloth_mode: cli-gen-prom
       sloth_objective: "95"
       sloth_service: autometrics
-      sloth_slo: success-rate-1-095
+      sloth_slo: success-rate-95
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-1-095
+- name: sloth-slo-alerts-autometrics-success-rate-95
   rules:
-  - alert: High Error Rate SLO 1 - 95%
+  - alert: High Error Rate SLO - 95%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (14.4 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (14.4 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (14.4 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (14.4 * 0.05)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (6 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (6 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (6 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (6 * 0.05)) without (sloth_window)
       )
     labels:
       category: success-rate
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 1 - 95%
+  - alert: High Error Rate SLO - 95%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (3 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (3 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (3 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (3 * 0.05)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (1 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (1 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-1-095", sloth_service="autometrics", sloth_slo="success-rate-1-095"} > (1 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-95", sloth_service="autometrics", sloth_slo="success-rate-95"} > (1 * 0.05)) without (sloth_window)
       )
     labels:
       category: success-rate
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-1-099
+- name: sloth-slo-sli-recordings-autometrics-success-rate-99
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[5m])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[5m])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[30m])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[30m])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[1h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[1h])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[2h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[2h])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[6h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[6h])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[1d])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[1d])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99",result="error"}[3d])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.99"}[3d])))
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"}[30d])
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-1-099
+- name: sloth-slo-meta-recordings-autometrics-success-rate-99
   rules:
   - record: slo:objective:ratio
     expr: vector(0.99)
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
   - record: slo:error_budget:ratio
     expr: vector(1-0.99)
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"}
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"}
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"}
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"}
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-1-099",
-      sloth_service="autometrics", sloth_slo="success-rate-1-099"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-99", sloth_service="autometrics",
+      sloth_slo="success-rate-99"}
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-099
+      sloth_id: autometrics-success-rate-99
       sloth_mode: cli-gen-prom
       sloth_objective: "99"
       sloth_service: autometrics
-      sloth_slo: success-rate-1-099
+      sloth_slo: success-rate-99
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-1-099
+- name: sloth-slo-alerts-autometrics-success-rate-99
   rules:
-  - alert: High Error Rate SLO 1 - 99%
+  - alert: High Error Rate SLO - 99%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (14.4 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (14.4 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (14.4 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (14.4 * 0.01)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (6 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (6 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (6 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (6 * 0.01)) without (sloth_window)
       )
     labels:
       category: success-rate
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 1 - 99%
+  - alert: High Error Rate SLO - 99%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (3 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (3 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (3 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (3 * 0.01)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (1 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (1 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-1-099", sloth_service="autometrics", sloth_slo="success-rate-1-099"} > (1 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-99", sloth_service="autometrics", sloth_slo="success-rate-99"} > (1 * 0.01)) without (sloth_window)
       )
     labels:
       category: success-rate
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-1-0999
+- name: sloth-slo-sli-recordings-autometrics-success-rate-999
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[5m])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[5m])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[30m])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[30m])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[1h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[1h])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[2h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[2h])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[6h])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[6h])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[1d])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[1d])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.9",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999",result="error"}[3d])))
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.9"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_count{objective="0.999"}[3d])))
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"}[30d])
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-1-0999
+- name: sloth-slo-meta-recordings-autometrics-success-rate-999
   rules:
   - record: slo:objective:ratio
     expr: vector(0.9990000000000001)
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
   - record: slo:error_budget:ratio
     expr: vector(1-0.9990000000000001)
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"}
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"}
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"}
+      slo:error_budget:ratio{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"}
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-1-0999",
-      sloth_service="autometrics", sloth_slo="success-rate-1-0999"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-999",
+      sloth_service="autometrics", sloth_slo="success-rate-999"}
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-0999
+      sloth_id: autometrics-success-rate-999
       sloth_mode: cli-gen-prom
       sloth_objective: "99.9"
       sloth_service: autometrics
-      sloth_slo: success-rate-1-0999
+      sloth_slo: success-rate-999
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-1-0999
+- name: sloth-slo-alerts-autometrics-success-rate-999
   rules:
-  - alert: High Error Rate SLO 1 - 99.9%
+  - alert: High Error Rate SLO - 99.9%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (6 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (6 * 0.0009999999999999432)) without (sloth_window)
       )
     labels:
       category: success-rate
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 1 - 99.9%
+  - alert: High Error Rate SLO - 99.9%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (3 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (3 * 0.0009999999999999432)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (1 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-1-0999", sloth_service="autometrics", sloth_slo="success-rate-1-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-999", sloth_service="autometrics", sloth_slo="success-rate-999"} > (1 * 0.0009999999999999432)) without (sloth_window)
       )
     labels:
       category: success-rate
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High error rate on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-1-09999
+- name: sloth-slo-sli-recordings-autometrics-latency-90
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[5m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[5m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[5m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[5m])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[30m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[30m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[30m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[30m])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[1h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[1h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[1h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[1h])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[2h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[2h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[2h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[2h])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[6h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[6h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[6h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[6h])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[1d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[1d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[1d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[1d])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="1",objective="99.99",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[3d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[3d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.9"}[3d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="1",objective="99.99"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.9"}[3d])))
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"}[30d])
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-1-09999
+- name: sloth-slo-meta-recordings-autometrics-latency-90
   rules:
   - record: slo:objective:ratio
-    expr: vector(0.9998999999999999)
+    expr: vector(0.9)
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
   - record: slo:error_budget:ratio
-    expr: vector(1-0.9998999999999999)
+    expr: vector(1-0.9)
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"}
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"}
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-1-09999",
-      sloth_service="autometrics", sloth_slo="success-rate-1-09999"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-90", sloth_service="autometrics",
+      sloth_slo="latency-90"}
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-success-rate-1-09999
+      sloth_id: autometrics-latency-90
       sloth_mode: cli-gen-prom
-      sloth_objective: "99.99"
+      sloth_objective: "90"
       sloth_service: autometrics
-      sloth_slo: success-rate-1-09999
+      sloth_slo: latency-90
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-1-09999
+- name: sloth-slo-alerts-autometrics-latency-90
   rules:
-  - alert: High Error Rate SLO 1 - 99.99%
+  - alert: High Latency SLO - 90%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (14.4 * 0.1)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (14.4 * 0.1)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (6 * 0.1)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (6 * 0.1)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 1 - 99.99%
+  - alert: High Latency SLO - 90%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (3 * 0.1)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (3 * 0.1)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (1 * 0.1)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-1-09999", sloth_service="autometrics", sloth_slo="success-rate-1-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-90", sloth_service="autometrics", sloth_slo="latency-90"} > (1 * 0.1)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-2-095
+- name: sloth-slo-sli-recordings-autometrics-latency-95
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[5m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[5m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[5m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[5m])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[30m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[30m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[30m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[30m])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[1h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[1h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[1h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[1h])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[2h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[2h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[2h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[2h])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[6h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[6h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[6h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[6h])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[1d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[1d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[1d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[1d])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="95",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[3d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[3d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.95"}[3d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="95"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.95"}[3d])))
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"}[30d])
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-2-095
+- name: sloth-slo-meta-recordings-autometrics-latency-95
   rules:
   - record: slo:objective:ratio
     expr: vector(0.95)
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
   - record: slo:error_budget:ratio
     expr: vector(1-0.95)
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"}
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"}
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-2-095",
-      sloth_service="autometrics", sloth_slo="success-rate-2-095"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-95", sloth_service="autometrics",
+      sloth_slo="latency-95"}
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-095
+      sloth_id: autometrics-latency-95
       sloth_mode: cli-gen-prom
       sloth_objective: "95"
       sloth_service: autometrics
-      sloth_slo: success-rate-2-095
+      sloth_slo: latency-95
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-2-095
+- name: sloth-slo-alerts-autometrics-latency-95
   rules:
-  - alert: High Error Rate SLO 2 - 95%
+  - alert: High Latency SLO - 95%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (14.4 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (14.4 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (14.4 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (14.4 * 0.05)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (6 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (6 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (6 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (6 * 0.05)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 2 - 95%
+  - alert: High Latency SLO - 95%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (3 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (3 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (3 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (3 * 0.05)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (1 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (1 * 0.05)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-2-095", sloth_service="autometrics", sloth_slo="success-rate-2-095"} > (1 * 0.05)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-95", sloth_service="autometrics", sloth_slo="latency-95"} > (1 * 0.05)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-2-099
+- name: sloth-slo-sli-recordings-autometrics-latency-99
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[5m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[5m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[5m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[5m])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[30m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[30m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[30m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[30m])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[1h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[1h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[1h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[1h])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[2h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[2h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[2h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[2h])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[6h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[6h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[6h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[6h])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[1d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[1d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[1d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[1d])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[3d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[3d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.99"}[3d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.99"}[3d])))
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"}[30d])
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-2-099
+- name: sloth-slo-meta-recordings-autometrics-latency-99
   rules:
   - record: slo:objective:ratio
     expr: vector(0.99)
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
   - record: slo:error_budget:ratio
     expr: vector(1-0.99)
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"}
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"}
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-2-099",
-      sloth_service="autometrics", sloth_slo="success-rate-2-099"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-99", sloth_service="autometrics",
+      sloth_slo="latency-99"}
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-099
+      sloth_id: autometrics-latency-99
       sloth_mode: cli-gen-prom
       sloth_objective: "99"
       sloth_service: autometrics
-      sloth_slo: success-rate-2-099
+      sloth_slo: latency-99
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-2-099
+- name: sloth-slo-alerts-autometrics-latency-99
   rules:
-  - alert: High Error Rate SLO 2 - 99%
+  - alert: High Latency SLO - 99%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (14.4 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (14.4 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (14.4 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (14.4 * 0.01)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (6 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (6 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (6 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (6 * 0.01)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 2 - 99%
+  - alert: High Latency SLO - 99%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (3 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (3 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (3 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (3 * 0.01)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (1 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (1 * 0.01)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-2-099", sloth_service="autometrics", sloth_slo="success-rate-2-099"} > (1 * 0.01)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-99", sloth_service="autometrics", sloth_slo="latency-99"} > (1 * 0.01)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-2-0999
+- name: sloth-slo-sli-recordings-autometrics-latency-999
   rules:
   - record: slo:sli_error:ratio_rate5m
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[5m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[5m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[5m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[5m])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 5m
   - record: slo:sli_error:ratio_rate30m
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[30m])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[30m]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[30m])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[30m])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 30m
   - record: slo:sli_error:ratio_rate1h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[1h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[1h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[1h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[1h])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 1h
   - record: slo:sli_error:ratio_rate2h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[2h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[2h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[2h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[2h])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 2h
   - record: slo:sli_error:ratio_rate6h
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[6h])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[6h]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[6h])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[6h])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 6h
   - record: slo:sli_error:ratio_rate1d
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[1d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[1d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[1d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[1d])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 1d
   - record: slo:sli_error:ratio_rate3d
     expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.9",result="error"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[3d])) - (sum by (slo_name, objective) (
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
+        and
+        label_join(rate(function_calls_duration_bucket{objective="0.999"}[3d]), "autometrics_check_label_equality", "", "le")
+      ))
+      )
       /
-      (sum(rate(function_calls_count{slo="2",objective="99.9"}[3d])))
+      (sum by (slo_name, objective) (rate(function_calls_duration_bucket{objective="0.999"}[3d])))
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"}[30d])
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"}[30d])
       / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"}[30d])
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"}[30d])
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-2-0999
+- name: sloth-slo-meta-recordings-autometrics-latency-999
   rules:
   - record: slo:objective:ratio
     expr: vector(0.9990000000000001)
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
   - record: slo:error_budget:ratio
     expr: vector(1-0.9990000000000001)
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
   - record: slo:time_period:days
     expr: vector(30)
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
   - record: slo:current_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"}
+      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"}
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
   - record: slo:period_burn_rate:ratio
     expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"}
+      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"}
       / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"}
+      slo:error_budget:ratio{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"}
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
   - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-2-0999",
-      sloth_service="autometrics", sloth_slo="success-rate-2-0999"}
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-999", sloth_service="autometrics",
+      sloth_slo="latency-999"}
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
   - record: sloth_slo_info
     expr: vector(1)
     labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-0999
+      sloth_id: autometrics-latency-999
       sloth_mode: cli-gen-prom
       sloth_objective: "99.9"
       sloth_service: autometrics
-      sloth_slo: success-rate-2-0999
+      sloth_slo: latency-999
       sloth_spec: prometheus/v1
       sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-2-0999
+- name: sloth-slo-alerts-autometrics-latency-999
   rules:
-  - alert: High Error Rate SLO 2 - 99.9%
+  - alert: High Latency SLO - 99.9%
     expr: |
       (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (6 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (6 * 0.0009999999999999432)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: page
       sloth_severity: page
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
-  - alert: High Error Rate SLO 2 - 99.9%
+  - alert: High Latency SLO - 99.9%
     expr: |
       (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (3 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (3 * 0.0009999999999999432)) without (sloth_window)
       )
       or
       (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (1 * 0.0009999999999999432)) without (sloth_window)
           and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-2-0999", sloth_service="autometrics", sloth_slo="success-rate-2-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
+          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-999", sloth_service="autometrics", sloth_slo="latency-999"} > (1 * 0.0009999999999999432)) without (sloth_window)
       )
     labels:
-      category: success-rate
+      category: latency
       severity: ticket
       sloth_severity: ticket
     annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-2-09999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[5m])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[5m])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[30m])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[30m])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[1h])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[1h])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[2h])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[2h])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[6h])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[6h])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[1d])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[1d])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_count{slo="2",objective="99.99",result="error"}[3d])))
-      /
-      (sum(rate(function_calls_count{slo="2",objective="99.99"}[3d])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"}[30d])
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-2-09999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-2-09999",
-      sloth_service="autometrics", sloth_slo="success-rate-2-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-success-rate-2-09999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.99"
-      sloth_service: autometrics
-      sloth_slo: success-rate-2-09999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-2-09999
-  rules:
-  - alert: High Error Rate SLO 2 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Error Rate SLO 2 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-2-09999", sloth_service="autometrics", sloth_slo="success-rate-2-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-3-095
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[5m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[5m])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[30m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[30m])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[1h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[1h])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[2h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[2h])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[6h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[6h])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[1d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[1d])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="95",result="error"}[3d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="95"}[3d])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"}[30d])
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-3-095
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.95)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.95)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"}
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"}
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-3-095",
-      sloth_service="autometrics", sloth_slo="success-rate-3-095"}
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-095
-      sloth_mode: cli-gen-prom
-      sloth_objective: "95"
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-095
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-3-095
-  rules:
-  - alert: High Error Rate SLO 3 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (14.4 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (14.4 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (6 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (6 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Error Rate SLO 3 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (3 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (3 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (1 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-3-095", sloth_service="autometrics", sloth_slo="success-rate-3-095"} > (1 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-3-099
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[5m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[5m])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[30m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[30m])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[1h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[1h])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[2h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[2h])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[6h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[6h])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[1d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[1d])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99",result="error"}[3d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99"}[3d])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"}[30d])
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-3-099
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.99)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.99)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"}
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"}
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-3-099",
-      sloth_service="autometrics", sloth_slo="success-rate-3-099"}
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-099
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99"
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-099
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-3-099
-  rules:
-  - alert: High Error Rate SLO 3 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (14.4 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (14.4 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (6 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (6 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Error Rate SLO 3 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (3 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (3 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (1 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-3-099", sloth_service="autometrics", sloth_slo="success-rate-3-099"} > (1 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-3-0999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[5m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[5m])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[30m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[30m])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[1h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[1h])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[2h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[2h])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[6h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[6h])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[1d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[1d])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.9",result="error"}[3d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.9"}[3d])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"}[30d])
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-3-0999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"}
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"}
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-3-0999",
-      sloth_service="autometrics", sloth_slo="success-rate-3-0999"}
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-0999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.9"
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-0999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-3-0999
-  rules:
-  - alert: High Error Rate SLO 3 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Error Rate SLO 3 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-3-0999", sloth_service="autometrics", sloth_slo="success-rate-3-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-success-rate-3-09999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[5m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[5m])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[30m])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[30m])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[1h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[1h])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[2h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[2h])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[6h])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[6h])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[1d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[1d])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_count{slo="3",objective="99.99",result="error"}[3d])))
-      /
-      (sum(rate(function_calls_count{slo="3",objective="99.99"}[3d])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"}[30d])
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-success-rate-3-09999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-success-rate-3-09999",
-      sloth_service="autometrics", sloth_slo="success-rate-3-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-success-rate-3-09999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.99"
-      sloth_service: autometrics
-      sloth_slo: success-rate-3-09999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-success-rate-3-09999
-  rules:
-  - alert: High Error Rate SLO 3 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Error Rate SLO 3 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-success-rate-3-09999", sloth_service="autometrics", sloth_slo="success-rate-3-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-1-095
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[5m])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[30m])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1h])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[2h])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[6h])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[1d])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.95"}[3d])))
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"}[30d])
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-1-095
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.95)
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.95)
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"}
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"}
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-1-095", sloth_service="autometrics",
-      sloth_slo="latency-1-095"}
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.95"
-      slo: "1"
-      sloth_id: autometrics-latency-1-095
-      sloth_mode: cli-gen-prom
-      sloth_objective: "95"
-      sloth_service: autometrics
-      sloth_slo: latency-1-095
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-1-095
-  rules:
-  - alert: High Latency SLO 1 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (14.4 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (14.4 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (6 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (6 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 1 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (3 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (3 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (1 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-1-095", sloth_service="autometrics", sloth_slo="latency-1-095"} > (1 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-1-099
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[5m])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[30m])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1h])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[2h])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[6h])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[1d])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.99"}[3d])))
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"}[30d])
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-1-099
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.99)
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.99)
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"}
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"}
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-1-099", sloth_service="autometrics",
-      sloth_slo="latency-1-099"}
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.99"
-      slo: "1"
-      sloth_id: autometrics-latency-1-099
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99"
-      sloth_service: autometrics
-      sloth_slo: latency-1-099
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-1-099
-  rules:
-  - alert: High Latency SLO 1 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (14.4 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (14.4 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (6 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (6 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 1 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (3 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (3 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (1 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-1-099", sloth_service="autometrics", sloth_slo="latency-1-099"} > (1 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-1-0999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[5m])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[30m])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1h])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[2h])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[6h])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[1d])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.999"}[3d])))
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"}[30d])
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-1-0999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"}
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"}
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics",
-      sloth_slo="latency-1-0999"}
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-0999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.9"
-      sloth_service: autometrics
-      sloth_slo: latency-1-0999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-1-0999
-  rules:
-  - alert: High Latency SLO 1 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 1 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-1-0999", sloth_service="autometrics", sloth_slo="latency-1-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-1-09999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[5m])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[30m])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1h])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[2h])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[6h])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[1d])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="1",objective="0.9999"}[3d])))
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"}[30d])
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-1-09999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics",
-      sloth_slo="latency-1-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.9999"
-      slo: "1"
-      sloth_id: autometrics-latency-1-09999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.99"
-      sloth_service: autometrics
-      sloth_slo: latency-1-09999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-1-09999
-  rules:
-  - alert: High Latency SLO 1 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 1 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-1-09999", sloth_service="autometrics", sloth_slo="latency-1-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-2-095
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[5m])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[30m])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1h])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[2h])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[6h])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[1d])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.95"}[3d])))
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"}[30d])
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-2-095
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.95)
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.95)
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"}
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"}
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-2-095", sloth_service="autometrics",
-      sloth_slo="latency-2-095"}
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.95"
-      slo: "2"
-      sloth_id: autometrics-latency-2-095
-      sloth_mode: cli-gen-prom
-      sloth_objective: "95"
-      sloth_service: autometrics
-      sloth_slo: latency-2-095
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-2-095
-  rules:
-  - alert: High Latency SLO 2 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (14.4 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (14.4 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (6 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (6 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 2 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (3 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (3 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (1 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-2-095", sloth_service="autometrics", sloth_slo="latency-2-095"} > (1 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-2-099
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[5m])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[30m])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1h])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[2h])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[6h])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[1d])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.99"}[3d])))
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"}[30d])
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-2-099
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.99)
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.99)
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"}
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"}
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-2-099", sloth_service="autometrics",
-      sloth_slo="latency-2-099"}
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.99"
-      slo: "2"
-      sloth_id: autometrics-latency-2-099
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99"
-      sloth_service: autometrics
-      sloth_slo: latency-2-099
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-2-099
-  rules:
-  - alert: High Latency SLO 2 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (14.4 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (14.4 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (6 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (6 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 2 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (3 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (3 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (1 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-2-099", sloth_service="autometrics", sloth_slo="latency-2-099"} > (1 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-2-0999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[5m])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[30m])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1h])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[2h])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[6h])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[1d])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.999"}[3d])))
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"}[30d])
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-2-0999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"}
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"}
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics",
-      sloth_slo="latency-2-0999"}
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-0999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.9"
-      sloth_service: autometrics
-      sloth_slo: latency-2-0999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-2-0999
-  rules:
-  - alert: High Latency SLO 2 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 2 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-2-0999", sloth_service="autometrics", sloth_slo="latency-2-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-2-09999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[5m])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[30m])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1h])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[2h])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[6h])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[1d])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="2",objective="0.9999"}[3d])))
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"}[30d])
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-2-09999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics",
-      sloth_slo="latency-2-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.9999"
-      slo: "2"
-      sloth_id: autometrics-latency-2-09999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.99"
-      sloth_service: autometrics
-      sloth_slo: latency-2-09999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-2-09999
-  rules:
-  - alert: High Latency SLO 2 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 2 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-2-09999", sloth_service="autometrics", sloth_slo="latency-2-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-3-095
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[5m])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[30m])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1h])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[2h])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[6h])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[1d])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.95"}[3d])))
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"}[30d])
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-3-095
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.95)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.95)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"}
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"}
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-3-095", sloth_service="autometrics",
-      sloth_slo="latency-3-095"}
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.95"
-      slo: "3"
-      sloth_id: autometrics-latency-3-095
-      sloth_mode: cli-gen-prom
-      sloth_objective: "95"
-      sloth_service: autometrics
-      sloth_slo: latency-3-095
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-3-095
-  rules:
-  - alert: High Latency SLO 3 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (14.4 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (14.4 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (6 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (6 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 3 - 95%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (3 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (3 * 0.05)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (1 * 0.05)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-3-095", sloth_service="autometrics", sloth_slo="latency-3-095"} > (1 * 0.05)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-3-099
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[5m])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[30m])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1h])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[2h])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[6h])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[1d])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.99"}[3d])))
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"}[30d])
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-3-099
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.99)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.99)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"}
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"}
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-3-099", sloth_service="autometrics",
-      sloth_slo="latency-3-099"}
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.99"
-      slo: "3"
-      sloth_id: autometrics-latency-3-099
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99"
-      sloth_service: autometrics
-      sloth_slo: latency-3-099
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-3-099
-  rules:
-  - alert: High Latency SLO 3 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (14.4 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (14.4 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (6 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (6 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 3 - 99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (3 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (3 * 0.01)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (1 * 0.01)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-3-099", sloth_service="autometrics", sloth_slo="latency-3-099"} > (1 * 0.01)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-3-0999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[5m])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[30m])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1h])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[2h])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[6h])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[1d])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.999"}[3d])))
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"}[30d])
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-3-0999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9990000000000001)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"}
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"}
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics",
-      sloth_slo="latency-3-0999"}
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-0999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.9"
-      sloth_service: autometrics
-      sloth_slo: latency-3-0999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-3-0999
-  rules:
-  - alert: High Latency SLO 3 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (6 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 3 - 99.9%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (3 * 0.0009999999999999432)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-3-0999", sloth_service="autometrics", sloth_slo="latency-3-0999"} > (1 * 0.0009999999999999432)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-- name: sloth-slo-sli-recordings-autometrics-latency-3-09999
-  rules:
-  - record: slo:sli_error:ratio_rate5m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[5m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[5m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[5m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[5m])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 5m
-  - record: slo:sli_error:ratio_rate30m
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[30m])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[30m]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[30m]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[30m])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 30m
-  - record: slo:sli_error:ratio_rate1h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1h])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 1h
-  - record: slo:sli_error:ratio_rate2h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[2h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[2h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[2h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[2h])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 2h
-  - record: slo:sli_error:ratio_rate6h
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[6h])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[6h]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[6h]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[6h])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 6h
-  - record: slo:sli_error:ratio_rate1d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[1d])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 1d
-  - record: slo:sli_error:ratio_rate3d
-    expr: |
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[3d])) - (sum(
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[3d]), "autometrics_check_label_equality", "", "target_latency")
-        and
-        label_join(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[3d]), "autometrics_check_label_equality", "", "le")
-      ))
-      )
-      /
-      (sum(rate(function_calls_duration_bucket{slo="3",objective="0.9999"}[3d])))
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 3d
-  - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"}[30d])
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_window: 30d
-- name: sloth-slo-meta-recordings-autometrics-latency-3-09999
-  rules:
-  - record: slo:objective:ratio
-    expr: vector(0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-  - record: slo:error_budget:ratio
-    expr: vector(1-0.9998999999999999)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-  - record: slo:time_period:days
-    expr: vector(30)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-  - record: slo:current_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-  - record: slo:period_burn_rate:ratio
-    expr: |
-      slo:sli_error:ratio_rate30d{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"}
-      / on(sloth_id, sloth_slo, sloth_service) group_left
-      slo:error_budget:ratio{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-  - record: slo:period_error_budget_remaining:ratio
-    expr: 1 - slo:period_burn_rate:ratio{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics",
-      sloth_slo="latency-3-09999"}
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-  - record: sloth_slo_info
-    expr: vector(1)
-    labels:
-      objective: "0.9999"
-      slo: "3"
-      sloth_id: autometrics-latency-3-09999
-      sloth_mode: cli-gen-prom
-      sloth_objective: "99.99"
-      sloth_service: autometrics
-      sloth_slo: latency-3-09999
-      sloth_spec: prometheus/v1
-      sloth_version: a9d9dc42fb66372fb1bd2c69ca354da4ace51b65
-- name: sloth-slo-alerts-autometrics-latency-3-09999
-  rules:
-  - alert: High Latency SLO 3 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate5m{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1h{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (14.4 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate30m{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (6 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: page
-      sloth_severity: page
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
-      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
-        burn rate is too fast.
-  - alert: High Latency SLO 3 - 99.99%
-    expr: |
-      (
-          max(slo:sli_error:ratio_rate2h{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate1d{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (3 * 0.00010000000000005117)) without (sloth_window)
-      )
-      or
-      (
-          max(slo:sli_error:ratio_rate6h{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-          and
-          max(slo:sli_error:ratio_rate3d{sloth_id="autometrics-latency-3-09999", sloth_service="autometrics", sloth_slo="latency-3-09999"} > (1 * 0.00010000000000005117)) without (sloth_window)
-      )
-    labels:
-      category: success-rate
-      severity: ticket
-      sloth_severity: ticket
-    annotations:
-      summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
-        rate is over expected.'
+      summary: 'High latency on SLO: {{$labels.slo_name}}'
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.

--- a/autometrics/src/objectives.rs
+++ b/autometrics/src/objectives.rs
@@ -95,10 +95,10 @@ pub enum ObjectivePercentage {
 impl ObjectivePercentage {
     const fn as_str(&self) -> &'static str {
         match self {
-            ObjectivePercentage::P90 => "90",
-            ObjectivePercentage::P95 => "95",
-            ObjectivePercentage::P99 => "99",
-            ObjectivePercentage::P99_9 => "99.9",
+            ObjectivePercentage::P90 => "0.9",
+            ObjectivePercentage::P95 => "0.95",
+            ObjectivePercentage::P99 => "0.99",
+            ObjectivePercentage::P99_9 => "0.999",
             #[cfg(feature = "custom_objectives")]
             ObjectivePercentage::Custom(custom) => custom,
         }


### PR DESCRIPTION
The previous commit didn't have the right settings when generating the rules, so this updates it. It also fixes a small inconsistency in the way the objective percentages were used as labels between the library and the rules.
