### PR TITLE
Fix latency SLO total query

### DIFF
--- a/autometrics-cli/src/sloth.rs
+++ b/autometrics-cli/src/sloth.rs
@@ -87,7 +87,7 @@ fn generate_latency_slo(objective_percentile: &str) -> String {
             and
             label_join(rate(function_calls_duration_bucket{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]), \"autometrics_check_label_equality\", \"\", \"le\")
           ))
-        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]))
+        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]))
     alerting:
       name: High Latency SLO - {objective_percentile}%
       labels:

--- a/autometrics.rules.yml
+++ b/autometrics.rules.yml
@@ -739,7 +739,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[5m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[5m])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -754,7 +754,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[30m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[30m])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -769,7 +769,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[1h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1h])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -784,7 +784,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[2h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[2h])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -799,7 +799,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[6h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[6h])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -814,7 +814,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[1d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1d])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -829,7 +829,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="90"}[3d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[3d])))
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -955,7 +955,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[5m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[5m])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -970,7 +970,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[30m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[30m])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -985,7 +985,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[1h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1h])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1000,7 +1000,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[2h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[2h])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1015,7 +1015,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[6h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[6h])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1030,7 +1030,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[1d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1d])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1045,7 +1045,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="95"}[3d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[3d])))
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1171,7 +1171,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[5m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[5m])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1186,7 +1186,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[30m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[30m])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1201,7 +1201,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[1h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1h])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1216,7 +1216,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[2h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[2h])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1231,7 +1231,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[6h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[6h])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1246,7 +1246,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[1d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1d])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1261,7 +1261,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99"}[3d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[3d])))
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1387,7 +1387,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[5m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[5m])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1402,7 +1402,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[30m])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[30m])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1417,7 +1417,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[1h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1h])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1432,7 +1432,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[2h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[2h])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1447,7 +1447,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[6h])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[6h])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1462,7 +1462,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[1d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1d])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1477,7 +1477,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_bucket{objective_percentile="99.9"}[3d])))
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[3d])))
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics


### PR DESCRIPTION
Summing the `function_calls_duration_bucket` gives the wrong result because each bucket is defined as less than or equal to the threshold, meaning values in the lower thresholds are also included in the higher thresholds. Instead, we need to use the `function_calls_duration_count`.
