### PR TITLE
Add minimum traffic threshold to alerts

### DIFF
--- a/autometrics-cli/src/sloth.rs
+++ b/autometrics-cli/src/sloth.rs
@@ -10,7 +10,7 @@ pub struct Arguments {
     #[clap(long, default_values = &["90", "95", "99", "99.9"])]
     objectives: Vec<String>,
 
-    /// Minimum traffic to trigger alerts in events/second.
+    /// Minimum traffic to trigger alerts, specified as events/second.
     ///
     /// If a service (all function sharing the same service name and objective
     /// percentage) has less than this many calls per second, then it won't

--- a/autometrics-cli/src/sloth.rs
+++ b/autometrics-cli/src/sloth.rs
@@ -10,19 +10,18 @@ pub struct Arguments {
     #[clap(long, default_values = &["90", "95", "99", "99.9"])]
     objectives: Vec<String>,
 
-    /// Minimum traffic to trigger alerts, specified as events/second.
+    /// Minimum traffic to trigger alerts, specified as events/minute.
     ///
-    /// If a service (all function sharing the same service name and objective
-    /// percentage) has less than this many calls per second, then it won't
-    /// trigger any alert.
+    /// Alerts will only trigger for an objective if the total call-rate of functions
+    /// comprising the objective is greather than this threshold.
     ///
-    /// Defaults to "at least 1 event per minute" (which is around
-    /// 0.16666...).
+    /// Defaults to "at least 1 event per minute"
     ///
-    /// Note that if a SLO has the same service name but with different
-    /// objective targets (as in "objective percentage") then the threshold
-    /// won't behave as expected.
-    #[clap(short, long, default_value_t = 0.16666666)]
+    /// Note that the total of calls is made on matching _both_ the "name"
+    /// attribute and the percentile targets; e.g. a function from an "API, 90%"
+    /// objective and one from an "API, 99%" objective count for 2 separate
+    /// low-traffic threshold.
+    #[clap(short, long, default_value_t = 1.0)]
     alerting_traffic_threshold: f64,
 
     /// Output path where the SLO file should be written.
@@ -34,7 +33,8 @@ pub struct Arguments {
 
 impl Arguments {
     pub fn run(&self) {
-        let sloth_file = generate_sloth_file(&self.objectives, self.alerting_traffic_threshold);
+        let sloth_file =
+            generate_sloth_file(&self.objectives, self.alerting_traffic_threshold / 60.0);
         if let Some(output_path) = &self.output {
             write(output_path, sloth_file)
                 .unwrap_or_else(|err| panic!("Error writing SLO file to {output_path:?}: {err}"));
@@ -76,7 +76,7 @@ fn generate_success_rate_slo(objective_percentile: &str, min_calls_per_second: f
     sli:
       events:
         error_query: sum by (objective_name, objective_percentile) (rate(function_calls_count{{objective_percentile=\"{objective_percentile}\",result=\"error\"}}[{{{{.window}}}}]))
-        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) > {min_calls_per_second}
+        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) >= {min_calls_per_second}
     alerting:
       name: High Error Rate SLO - {objective_percentile}%
       labels:
@@ -108,7 +108,7 @@ fn generate_latency_slo(objective_percentile: &str, min_calls_per_second: f64) -
             and
             label_join(rate(function_calls_duration_bucket{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]), \"autometrics_check_label_equality\", \"\", \"le\")
           ))
-        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) > {min_calls_per_second}
+        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) >= {min_calls_per_second}
     alerting:
       name: High Latency SLO - {objective_percentile}%
       labels:

--- a/autometrics-cli/src/sloth.rs
+++ b/autometrics-cli/src/sloth.rs
@@ -10,6 +10,21 @@ pub struct Arguments {
     #[clap(long, default_values = &["90", "95", "99", "99.9"])]
     objectives: Vec<String>,
 
+    /// Minimum traffic to trigger alerts in events/second.
+    ///
+    /// If a service (all function sharing the same service name and objective
+    /// percentage) has less than this many calls per second, then it won't
+    /// trigger any alert.
+    ///
+    /// Defaults to "at least 1 event per minute" (which is around
+    /// 0.16666...).
+    ///
+    /// Note that if a SLO has the same service name but with different
+    /// objective targets (as in "objective percentage") then the threshold
+    /// won't behave as expected.
+    #[clap(short, long, default_value_t = 0.16666666)]
+    alerting_traffic_threshold: f64,
+
     /// Output path where the SLO file should be written.
     ///
     /// If not specified, the SLO file will be printed to stdout.
@@ -19,17 +34,17 @@ pub struct Arguments {
 
 impl Arguments {
     pub fn run(&self) {
-        let sloth_file = generate_sloth_file(&self.objectives);
+        let sloth_file = generate_sloth_file(&self.objectives, self.alerting_traffic_threshold);
         if let Some(output_path) = &self.output {
             write(output_path, sloth_file)
-                .expect(&format!("Error writing SLO file to {:?}", output_path));
+                .unwrap_or_else(|err| panic!("Error writing SLO file to {output_path:?}: {err}"));
         } else {
             println!("{}", sloth_file);
         }
     }
 }
 
-fn generate_sloth_file(objectives: &[impl AsRef<str>]) -> String {
+fn generate_sloth_file(objectives: &[impl AsRef<str>], min_calls_per_second: f64) -> String {
     let mut sloth_file = "version: prometheus/v1
 service: autometrics
 slos:
@@ -37,16 +52,22 @@ slos:
     .to_string();
 
     for objective in objectives {
-        sloth_file.push_str(&generate_success_rate_slo(objective.as_ref()));
+        sloth_file.push_str(&generate_success_rate_slo(
+            objective.as_ref(),
+            min_calls_per_second,
+        ));
     }
     for objective in objectives {
-        sloth_file.push_str(&generate_latency_slo(objective.as_ref()));
+        sloth_file.push_str(&generate_latency_slo(
+            objective.as_ref(),
+            min_calls_per_second,
+        ));
     }
 
     sloth_file
 }
 
-fn generate_success_rate_slo(objective_percentile: &str) -> String {
+fn generate_success_rate_slo(objective_percentile: &str, min_calls_per_second: f64) -> String {
     let objective_percentile_no_decimal = objective_percentile.replace('.', "_");
 
     format!("  - name: success-rate-{objective_percentile_no_decimal}
@@ -55,7 +76,7 @@ fn generate_success_rate_slo(objective_percentile: &str) -> String {
     sli:
       events:
         error_query: sum by (objective_name, objective_percentile) (rate(function_calls_count{{objective_percentile=\"{objective_percentile}\",result=\"error\"}}[{{{{.window}}}}]))
-        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) > 0
+        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) > {min_calls_per_second}
     alerting:
       name: High Error Rate SLO - {objective_percentile}%
       labels:
@@ -71,7 +92,7 @@ fn generate_success_rate_slo(objective_percentile: &str) -> String {
 ")
 }
 
-fn generate_latency_slo(objective_percentile: &str) -> String {
+fn generate_latency_slo(objective_percentile: &str, min_calls_per_second: f64) -> String {
     let objective_percentile_no_decimal = objective_percentile.replace('.', "_");
 
     format!("  - name: latency-{objective_percentile_no_decimal}
@@ -87,7 +108,7 @@ fn generate_latency_slo(objective_percentile: &str) -> String {
             and
             label_join(rate(function_calls_duration_bucket{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]), \"autometrics_check_label_equality\", \"\", \"le\")
           ))
-        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) > 0
+        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) > {min_calls_per_second}
     alerting:
       name: High Latency SLO - {objective_percentile}%
       labels:

--- a/autometrics.rules.yml
+++ b/autometrics.rules.yml
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -20,7 +20,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -30,7 +30,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -40,7 +40,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -50,7 +50,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -60,7 +60,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -191,7 +191,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -201,7 +201,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -211,7 +211,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -221,7 +221,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -231,7 +231,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -241,7 +241,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -251,7 +251,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -372,7 +372,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -382,7 +382,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -392,7 +392,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -402,7 +402,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -412,7 +412,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -422,7 +422,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -432,7 +432,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -553,7 +553,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -563,7 +563,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -573,7 +573,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -583,7 +583,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -593,7 +593,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -603,7 +603,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -613,7 +613,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -739,7 +739,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -754,7 +754,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -769,7 +769,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -784,7 +784,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -799,7 +799,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -814,7 +814,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -829,7 +829,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -955,7 +955,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -970,7 +970,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -985,7 +985,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1000,7 +1000,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1015,7 +1015,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1030,7 +1030,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1045,7 +1045,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1171,7 +1171,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1186,7 +1186,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1201,7 +1201,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1216,7 +1216,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1231,7 +1231,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1246,7 +1246,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1261,7 +1261,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1387,7 +1387,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[5m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[5m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1402,7 +1402,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[30m])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[30m])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1417,7 +1417,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1432,7 +1432,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[2h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[2h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1447,7 +1447,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[6h])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[6h])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1462,7 +1462,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1477,7 +1477,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[3d])) > 0)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[3d])) > 0.16666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics

--- a/autometrics.rules.yml
+++ b/autometrics.rules.yml
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -20,7 +20,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -30,7 +30,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -40,7 +40,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -50,7 +50,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -60,7 +60,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="90"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-90
       sloth_service: autometrics
@@ -191,7 +191,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -201,7 +201,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -211,7 +211,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -221,7 +221,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -231,7 +231,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -241,7 +241,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -251,7 +251,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="95"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-95
       sloth_service: autometrics
@@ -372,7 +372,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -382,7 +382,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -392,7 +392,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -402,7 +402,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -412,7 +412,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -422,7 +422,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -432,7 +432,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99
       sloth_service: autometrics
@@ -553,7 +553,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[5m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -563,7 +563,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[30m])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -573,7 +573,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[1h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -583,7 +583,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[2h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -593,7 +593,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[6h])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -603,7 +603,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[1d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -613,7 +613,7 @@ groups:
     expr: |
       (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9",result="error"}[3d])))
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_count{objective_percentile="99.9"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-success-rate-99_9
       sloth_service: autometrics
@@ -739,7 +739,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -754,7 +754,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -769,7 +769,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -784,7 +784,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -799,7 +799,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -814,7 +814,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -829,7 +829,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="90"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-90
       sloth_service: autometrics
@@ -955,7 +955,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -970,7 +970,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -985,7 +985,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1000,7 +1000,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1015,7 +1015,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1030,7 +1030,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1045,7 +1045,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="95"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-95
       sloth_service: autometrics
@@ -1171,7 +1171,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1186,7 +1186,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1201,7 +1201,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1216,7 +1216,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1231,7 +1231,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1246,7 +1246,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1261,7 +1261,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99
       sloth_service: autometrics
@@ -1387,7 +1387,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[5m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[5m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1402,7 +1402,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[30m])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[30m])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1417,7 +1417,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1432,7 +1432,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[2h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[2h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1447,7 +1447,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[6h])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[6h])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1462,7 +1462,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[1d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics
@@ -1477,7 +1477,7 @@ groups:
       ))
       )
       /
-      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[3d])) > 0.16666666)
+      (sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{objective_percentile="99.9"}[3d])) >= 0.016666666666666666)
     labels:
       sloth_id: autometrics-latency-99_9
       sloth_service: autometrics


### PR DESCRIPTION
The minimum traffic threshold defaults to 1 call per minute across all
functions of a SLO, but can be modified in the CLI

Ref: https://github.com/orgs/autometrics-dev/discussions/9