### PR TITLE
Bump metrics-exporter-prometheus from 0.11 to 0.12

### DIFF
--- a/autometrics/Cargo.toml
+++ b/autometrics/Cargo.toml
@@ -36,7 +36,7 @@ opentelemetry_api = { version = "0.18", default-features = false, features = ["m
 metrics = { version = "0.20", default-features = false, optional = true }
 
 # Used for prometheus-exporter feature
-metrics-exporter-prometheus = { version = "0.11", default-features = false, optional = true }
+metrics-exporter-prometheus = { version = "0.12", default-features = false, optional = true }
 once_cell = { version = "1.17", optional = true }
 opentelemetry-prometheus = { version = "0.11", optional = true }
 opentelemetry_sdk = { version = "0.18", default-features = false, features = ["metrics"], optional = true }


### PR DESCRIPTION
This, transitively, replaces the archived [mach crate](lib.rs/mach) with [mach2](lib.rs/mach2) which is actively maintained.