### PR TITLE
Add a type annotation to generated code to allow type inference to work.

### DIFF
--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -3,7 +3,7 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::env;
-use syn::{parse_macro_input, ImplItem, ItemFn, ItemImpl, Result};
+use syn::{parse_macro_input, ImplItem, ItemFn, ItemImpl, Result, ReturnType};
 
 mod parse;
 
@@ -49,6 +49,12 @@ fn instrument_function(args: &AutometricsArgs, item: ItemFn) -> Result<TokenStre
 
     // Build the documentation we'll add to the function's RustDocs
     let metrics_docs = create_metrics_docs(&prometheus_url, &function_name, args.track_concurrency);
+
+    // Type annotation to allow type inference to work on return expressions (such as `.collect()`).
+    let return_type = match sig.output {
+        ReturnType::Default => quote! { () },
+        ReturnType::Type(_, ref t) => quote! { #t },
+    };
 
     // Wrap the body of the original function, using a slightly different approach based on whether the function is async
     let call_function = if sig.asyncness.is_some() {
@@ -136,7 +142,7 @@ fn instrument_function(args: &AutometricsArgs, item: ItemFn) -> Result<TokenStre
                 AutometricsTracker::start(#gauge_labels)
             };
 
-            let result = #call_function;
+            let result: #return_type = #call_function;
 
             {
                 use autometrics::__private::{HistogramLabels, TrackMetrics};

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -124,7 +124,8 @@ mod tracker;
 ///        Self
 ///     }
 ///
-///     fn my_function(&self) {
+///     fn my_function(&self) -> Vec<usize> {
+///        # (0..10).collect()
 ///        // ...
 ///    }
 /// }


### PR DESCRIPTION
Since the generated code wraps the original function body in an expression of the form
`let return = { /* original function body /* };`, this can cause type inference to not work on
return expressions like the following:

```rust
#[autometrics]
fn foo() -> Vec<usize> {
    (0..10).collect()
}
```

This patch puts the function's return type as an explicit type annotation on the `let return =` in
the generated code.
