### PR TITLE
Use last_over_time to fix build info query

### DIFF
--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -10,7 +10,8 @@ mod parse;
 const COUNTER_NAME_PROMETHEUS: &str = "function_calls_count";
 const HISTOGRAM_BUCKET_NAME_PROMETHEUS: &str = "function_calls_duration_bucket";
 const GAUGE_NAME_PROMETHEUS: &str = "function_calls_concurrent";
-const ADD_BUILD_INFO_LABELS: &str = "* on (instance, job) group_left(version, commit) build_info";
+const ADD_BUILD_INFO_LABELS: &str =
+    "* on (instance, job) group_left(version, commit) last_over_time(build_info[1s])";
 
 const DEFAULT_PROMETHEUS_URL: &str = "http://localhost:9090";
 


### PR DESCRIPTION
When the version switches, we observed a problem where Prometheus would keep the value of the old gauge in memory and return it for the query using the build_info metric. This is a problem with our group_left query because Prometheus would complain that there are multiple matching label sets (the old and new version info).

Adding the last_over_time function seems to solve this because it seems to get rid of the old gauge value as soon as it no longer appears in the scrape.
