### PR TITLE
Add percentile_latency label to latency query

### DIFF
--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -282,8 +282,9 @@ fn latency_query(bucket_name: &str, label_key: &str, label_value: &str) -> Strin
         "sum by (le, function, module, commit, version) (rate({bucket_name}{{{label_key}=\"{label_value}\"}}[5m]) {ADD_BUILD_INFO_LABELS})"
     );
     format!(
-        "histogram_quantile(0.99, {latency}) or
-histogram_quantile(0.95, {latency})"
+        "label_replace(histogram_quantile(0.99, {latency}), \"percentile_latency\", \"99\", \"function\", \".*\")
+or
+label_replace(histogram_quantile(0.95, {latency}), \"percentile_latency\", \"95\", \"function\", \".*\")"
     )
 }
 

--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -282,9 +282,9 @@ fn latency_query(bucket_name: &str, label_key: &str, label_value: &str) -> Strin
         "sum by (le, function, module, commit, version) (rate({bucket_name}{{{label_key}=\"{label_value}\"}}[5m]) {ADD_BUILD_INFO_LABELS})"
     );
     format!(
-        "label_replace(histogram_quantile(0.99, {latency}), \"percentile_latency\", \"99\", \"function\", \".*\")
+        "label_replace(histogram_quantile(0.99, {latency}), \"percentile_latency\", \"99\", \"\", \"\")
 or
-label_replace(histogram_quantile(0.95, {latency}), \"percentile_latency\", \"95\", \"function\", \".*\")"
+label_replace(histogram_quantile(0.95, {latency}), \"percentile_latency\", \"95\", \"\", \"\")"
     )
 }
 


### PR DESCRIPTION
The previous query only returned one percentile latency because all of the labels from the two `histogram_quantile` queries were the same. This adds another label so that the graph will actually show the two lines.
