### PR TITLE
Specify opentelemetry_api version as >=0.18

### DIFF
--- a/autometrics/Cargo.toml
+++ b/autometrics/Cargo.toml
@@ -32,7 +32,10 @@ autometrics-macros = { workspace = true }
 spez = { version = "0.1.2" }
 
 # Used for opentelemetry feature
-opentelemetry_api = { version = "0.18", default-features = false, features = ["metrics"], optional = true }
+# Note that we specify a version range because users may want to use an older version of this crate for collecting
+# and exporting metrics. The version of this crate autometrics uses to produce the metrics must
+# match the version of this crate the user uses to collect and export the metrics.
+opentelemetry_api = { version = ">=0.18", default-features = false, features = ["metrics"], optional = true }
 
 # Use for metrics feature
 metrics = { version = "0.21", default-features = false, optional = true }
@@ -40,8 +43,8 @@ metrics = { version = "0.21", default-features = false, optional = true }
 # Used for prometheus-exporter feature
 metrics-exporter-prometheus = { version = "0.12", default-features = false, optional = true }
 once_cell = { version = "1.17", optional = true }
-opentelemetry-prometheus = { version = "0.11", optional = true }
-opentelemetry_sdk = { version = "0.18", default-features = false, features = ["metrics"], optional = true }
+opentelemetry-prometheus = { version = "0.12", optional = true }
+opentelemetry_sdk = { version = "0.19", default-features = false, features = ["metrics"], optional = true }
 prometheus = { version = "0.13", default-features = false, optional = true }
 
 # Used for prometheus feature


### PR DESCRIPTION
The version of the `opentelemetry_api` crate used by autometrics must exactly match the one included by users to collect and export the metrics. Otherwise, cargo will pull in both versions and the global meter used by autometrics will be different than the one used for collection.

If or when opentelemetry_api makes breaking changes to the part of the API we're using, we'll need to update the dependency here to specify a maximum version. But until then, this seems like the only way to ensure that the version autometrics uses will match the more specific version pulled in by the user.

Resolves https://github.com/autometrics-dev/autometrics-rs/issues/91
