### PR TITLE
Prometheus-exporter feature shouldn't enable the prometheus crate for producing metrics

### DIFF
--- a/autometrics/Cargo.toml
+++ b/autometrics/Cargo.toml
@@ -22,7 +22,7 @@ prometheus-exporter = [
   "once_cell",
   "opentelemetry-prometheus",
   "opentelemetry_sdk",
-  "prometheus"
+  "dep:prometheus"
 ]
 custom-objective-percentile = []
 custom-objective-latency = []


### PR DESCRIPTION
Currently, the `prometheus-exporter` feature enables the `prometheus` feature, which not only pulls in the `prometheus` dependency (which we want), but it also overrides the default metrics library used to produce metrics so `prometheus` is used instead of `opentelemetry`.

When this mistake is corrected, the tests fail, indicating that there is a bug with how we're producing metrics when using `opentelemetry`.
