### PR TITLE
Use #[cfg(feature = ...)] directly for public features

### DIFF
--- a/autometrics/src/exemplars/mod.rs
+++ b/autometrics/src/exemplars/mod.rs
@@ -77,7 +77,7 @@ pub mod tracing;
 #[cfg(exemplars_tracing_opentelemetry)]
 mod tracing_opentelemetry;
 
-#[cfg(all(not(doc), exemplars_tracing, exemplars_tracing_opentelemetry,))]
+#[cfg(all(not(doc), exemplars_tracing, exemplars_tracing_opentelemetry))]
 compile_error!("Only one of the exemplars-tracing and exemplars-tracing-opentelemetry features can be enabled at a time");
 
 #[cfg(not(prometheus_client))]

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -7,11 +7,14 @@
 
 pub mod backends;
 mod constants;
-#[cfg(exemplars)]
+#[cfg(any(
+    feature = "exemplars-tracing",
+    feature = "exemplars-tracing-opentelemetry"
+))]
 pub mod exemplars;
 mod labels;
 pub mod objectives;
-#[cfg(prometheus_exporter)]
+#[cfg(feature = "prometheus-exporter")]
 pub mod prometheus_exporter;
 mod task_local;
 mod tracker;
@@ -170,7 +173,7 @@ pub use autometrics_macros::autometrics;
 pub use autometrics_macros::ResultLabels;
 
 // Optional exports
-#[cfg(prometheus_exporter)]
+#[cfg(feature = "prometheus-exporter")]
 #[deprecated(
     since = "0.5.0",
     note = "Use autometrics::prometheus_exporter::encode_to_string instead. This will be removed in v0.6"
@@ -179,7 +182,7 @@ pub use autometrics_macros::ResultLabels;
 pub fn encode_global_metrics() -> Result<String, prometheus_exporter::EncodingError> {
     prometheus_exporter::encode_to_string()
 }
-#[cfg(prometheus_exporter)]
+#[cfg(feature = "prometheus-exporter")]
 #[deprecated(
     since = "0.5.0",
     note = "Use autometrics::prometheus_exporter::init instead. This will be removed in v0.6"

--- a/autometrics/src/objectives.rs
+++ b/autometrics/src/objectives.rs
@@ -24,7 +24,7 @@
 //! }
 //! ```
 
-#[cfg(feature = "prometheus-client")]
+#[cfg(prometheus_client)]
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 
 /// A Service-Level Objective (SLO) for a function or group of functions.

--- a/autometrics/src/objectives.rs
+++ b/autometrics/src/objectives.rs
@@ -24,7 +24,7 @@
 //! }
 //! ```
 
-#[cfg(prometheus_client)]
+#[cfg(feature = "prometheus-client")]
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 
 /// A Service-Level Objective (SLO) for a function or group of functions.
@@ -139,7 +139,7 @@ pub enum ObjectivePercentile {
     /// 1. generate a custom Sloth file using the [autometrics-cli](https://github.com/autometrics-dev/autometrics-rs/tree/main/autometrics-cli) that includes this objective
     /// 2. use [Sloth](https://sloth.dev) to generate the Prometheus recording and alerting rules
     /// 3. configure your Prometheus instance to use the generated rules
-    #[cfg(custom_objective_percentile)]
+    #[cfg(feature = "custom-objective-percentile")]
     Custom(&'static str),
 }
 
@@ -150,7 +150,7 @@ impl ObjectivePercentile {
             ObjectivePercentile::P95 => "95",
             ObjectivePercentile::P99 => "99",
             ObjectivePercentile::P99_9 => "99.9",
-            #[cfg(custom_objective_percentile)]
+            #[cfg(feature = "custom-objective-percentile")]
             ObjectivePercentile::Custom(custom) => custom,
         }
     }
@@ -206,13 +206,13 @@ pub enum ObjectiveLatency {
     /// If it is not, the alerting rules will not work.
     /// This is because the recording rules compare this to the value
     /// of the `le` label on the histogram buckets.
-    #[cfg(custom_objective_latency)]
+    #[cfg(feature = "custom-objective-latency")]
     Custom(&'static str),
 }
 
-#[cfg(all(not(doc), custom_objective_latency, prometheus))]
-compile_error!("The `custom-objective-latencies` feature is not currently compatible with the `prometheus` feature because \
-the autometrics API does not provide a way to configure the histogram buckets passed to the prometheus crate's metrics functions. \
+#[cfg(all(not(doc), custom_objective_latency, any(prometheus, prometheus_client)))]
+compile_error!("The `custom-objective-latencies` feature is not currently compatible with the `prometheus` and `prometheus-client` backends because \
+the autometrics API does not provide a way to configure the histogram buckets passed to the crate's metrics functions. \
 Please open an issue on GitHub if you would like to see this feature added.");
 
 #[cfg(all(not(doc), custom_objective_latency, prometheus_exporter))]
@@ -237,7 +237,7 @@ impl ObjectiveLatency {
             ObjectiveLatency::Ms5000 => "5",
             ObjectiveLatency::Ms7500 => "7.5",
             ObjectiveLatency::Ms10000 => "10",
-            #[cfg(custom_objective_latency)]
+            #[cfg(feature = "custom-objective-latency")]
             ObjectiveLatency::Custom(custom) => custom,
         }
     }


### PR DESCRIPTION
So that on docs.rs it says "Available on crate feature ... only" instead of "Available on exemplars and exemplars_tracing only."
