### PR TITLE
Enable examples to run against already running Prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ data
 
 # Trybuild compilation error outputs in development phase
 wip
+
+# VS Code
+.vscode

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,3 +16,12 @@ cargo run --package example-{name of example}
 ## Full Example
 
 Look at the [full-api](./full-api) example to see autometrics in use in an example API server built with `axum`, `thiserror`, and `tokio`.
+
+## Prometheus
+
+If Prometheus is installed locally example may start it as needed. You can also start Prometheus before running examples with Docker like this:
+
+```
+# from this directory
+docker run  -v $(pwd)/util/prometheus.yml:/prometheus/prometheus.yml --network host prom/prometheus --enable-feature=exemplar-storage
+```

--- a/examples/util/Cargo.toml
+++ b/examples/util/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8"
+sysinfo = "0.29.2"
 tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
If I wanted to use Prometheus from Docker  for examples I hit issue that examples wanted to start new one, locally installed.
This small change enables to run examples if Prometheus process is already running locally.