### PR TITLE
Add the `service.name` label to all metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Basic benchmarking
+- All metrics now have a `service.name` label attached. This is set via runtime environment
+  variable (`AUTOMETRICS_SERVICE_NAME` or `OTEL_SERVICE_NAME`), or falls back to the crate
+  name defined in the `Cargo.toml`
 
 ### Changed
 

--- a/autometrics-cli/src/sloth.rs
+++ b/autometrics-cli/src/sloth.rs
@@ -75,14 +75,14 @@ fn generate_success_rate_slo(objective_percentile: &str, min_calls_per_second: f
     description: Common SLO based on function success rates
     sli:
       events:
-        error_query: sum by (objective_name, objective_percentile) (rate({{__name__=~\"function_calls_count(?:_total)?\",objective_percentile=\"{objective_percentile}\",result=\"error\"}}[{{{{.window}}}}]))
-        total_query: sum by (objective_name, objective_percentile) (rate({{__name__=~\"function_calls_count(?:_total)?\",objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) >= {min_calls_per_second}
+        error_query: sum by (objective_name, objective_percentile, service_name) (rate({{__name__=~\"function_calls_count(?:_total)?\",objective_percentile=\"{objective_percentile}\",result=\"error\"}}[{{{{.window}}}}]))
+        total_query: sum by (objective_name, objective_percentile, service_name) (rate({{__name__=~\"function_calls_count(?:_total)?\",objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) >= {min_calls_per_second}
     alerting:
       name: High Error Rate SLO - {objective_percentile}%
       labels:
         category: success-rate
       annotations:
-        summary: \"High error rate on SLO: {{{{$labels.objective_name}}}}\"
+        summary: \"High error rate on the `{{{{$labels.objective_name}}}}` SLO for the `{{{{$labels.service_name}}}}` service\"
       page_alert:
         labels:
           severity: page
@@ -101,20 +101,20 @@ fn generate_latency_slo(objective_percentile: &str, min_calls_per_second: f64) -
     sli:
       events:
         error_query: >
-          sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]))
+          sum by (objective_name, objective_percentile, service_name) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]))
           -
-          (sum by (objective_name, objective_percentile) (
+          (sum by (objective_name, objective_percentile, service_name) (
             label_join(rate(function_calls_duration_bucket{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]), \"autometrics_check_label_equality\", \"\", \"objective_latency_threshold\")
             and
             label_join(rate(function_calls_duration_bucket{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}]), \"autometrics_check_label_equality\", \"\", \"le\")
           ))
-        total_query: sum by (objective_name, objective_percentile) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) >= {min_calls_per_second}
+        total_query: sum by (objective_name, objective_percentile, service_name) (rate(function_calls_duration_count{{objective_percentile=\"{objective_percentile}\"}}[{{{{.window}}}}])) >= {min_calls_per_second}
     alerting:
       name: High Latency SLO - {objective_percentile}%
       labels:
         category: latency
       annotations:
-        summary: \"High latency on SLO: {{{{$labels.objective_name}}}}\"
+        summary: \"High latency on the `{{{{$labels.objective_name}}}}` SLO for the `{{{{$labels.service_name}}}}` service\"
       page_alert:
         labels:
           severity: page

--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -319,19 +319,19 @@ fn make_prometheus_url(url: &str, query: &str, comment: &str) -> String {
 }
 
 fn request_rate_query(label_key: &str, label_value: &str) -> String {
-    format!("sum by (function, module, commit, version) (rate({{__name__=~\"function_calls(_count)?(_total)?\",{label_key}=\"{label_value}\"}}[5m]) {ADD_BUILD_INFO_LABELS})")
+    format!("sum by (function, module, service_name, commit, version) (rate({{__name__=~\"function_calls(_count)?(_total)?\",{label_key}=\"{label_value}\"}}[5m]) {ADD_BUILD_INFO_LABELS})")
 }
 
 fn error_ratio_query(label_key: &str, label_value: &str) -> String {
     let request_rate = request_rate_query(label_key, label_value);
-    format!("(sum by (function, module, commit, version) (rate({{__name__=~\"function_calls(_count)?(_total)?\",{label_key}=\"{label_value}\",result=\"error\"}}[5m]) {ADD_BUILD_INFO_LABELS}))
+    format!("(sum by (function, module, service_name, commit, version) (rate({{__name__=~\"function_calls(_count)?(_total)?\",{label_key}=\"{label_value}\",result=\"error\"}}[5m]) {ADD_BUILD_INFO_LABELS}))
 /
 ({request_rate})",)
 }
 
 fn latency_query(label_key: &str, label_value: &str) -> String {
     let latency = format!(
-        "sum by (le, function, module, commit, version) (rate(function_calls_duration_bucket{{{label_key}=\"{label_value}\"}}[5m]) {ADD_BUILD_INFO_LABELS})"
+        "sum by (le, function, module, service_name, commit, version) (rate(function_calls_duration_bucket{{{label_key}=\"{label_value}\"}}[5m]) {ADD_BUILD_INFO_LABELS})"
     );
     format!(
         "label_replace(histogram_quantile(0.99, {latency}), \"percentile_latency\", \"99\", \"\", \"\")
@@ -341,5 +341,5 @@ label_replace(histogram_quantile(0.95, {latency}), \"percentile_latency\", \"95\
 }
 
 fn concurrent_calls_query(label_key: &str, label_value: &str) -> String {
-    format!("sum by (function, module, commit, version) (function_calls_concurrent{{{label_key}=\"{label_value}\"}} {ADD_BUILD_INFO_LABELS})")
+    format!("sum by (function, module, service_name, commit, version) (function_calls_concurrent{{{label_key}=\"{label_value}\"}} {ADD_BUILD_INFO_LABELS})")
 }

--- a/autometrics/src/README.md
+++ b/autometrics/src/README.md
@@ -107,6 +107,17 @@ pub fn main() {
 }
 ```
 
+### Service name
+
+All metrics produced by Autometrics have a label called `service.name` (or `service_name` when exported to Prometheus) attached to identify the logical service they are part of.
+
+You may want to override the default service name, for example if you are running multiple instances of the same code base as separate services and want to differentiate between the metrics produced by each one.
+
+The service name is loaded from the following environment variables, in this order:
+1. `AUTOMETRICS_SERVICE_NAME` (at runtime)
+2. `OTEL_SERVICE_NAME` (at runtime)
+3. `CARGO_PKG_NAME` (at compile time)
+
 ### Feature flags
 
 - `prometheus-exporter` - exports a Prometheus metrics collector and exporter. This is compatible with any of the [Metrics backends](#metrics-backends) and uses `prometheus-client` by default if none are explicitly selected

--- a/autometrics/src/constants.rs
+++ b/autometrics/src/constants.rs
@@ -32,3 +32,5 @@ pub const OBJECTIVE_LATENCY_THRESHOLD_PROMETHEUS: &str = "objective_latency_thre
 pub const VERSION_KEY: &str = "version";
 pub const COMMIT_KEY: &str = "commit";
 pub const BRANCH_KEY: &str = "branch";
+pub const SERVICE_NAME_KEY: &str = "service.name";
+pub const SERVICE_NAME_KEY_PROMETHEUS: &str = "service_name";

--- a/autometrics/src/labels.rs
+++ b/autometrics/src/labels.rs
@@ -194,7 +194,11 @@ impl HistogramLabels {
     }
 
     pub fn to_vec(&self) -> Vec<Label> {
-        let mut labels = vec![(FUNCTION_KEY, self.function), (MODULE_KEY, self.module)];
+        let mut labels = vec![
+            (FUNCTION_KEY, self.function),
+            (MODULE_KEY, self.module),
+            (SERVICE_NAME_KEY, self.service_name),
+        ];
 
         if let Some(objective_name) = self.objective_name {
             labels.push((OBJECTIVE_NAME, objective_name));

--- a/autometrics/src/labels.rs
+++ b/autometrics/src/labels.rs
@@ -1,7 +1,6 @@
 use crate::{constants::*, objectives::*};
 #[cfg(prometheus_client)]
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
-use std::ops::Deref;
 
 pub(crate) type Label = (&'static str, &'static str);
 pub type ResultAndReturnTypeLabels = (&'static str, Option<&'static str>);
@@ -15,14 +14,21 @@ pub struct BuildInfoLabels {
     pub(crate) branch: &'static str,
     pub(crate) commit: &'static str,
     pub(crate) version: &'static str,
+    pub(crate) service_name: &'static str,
 }
 
 impl BuildInfoLabels {
-    pub fn new(version: &'static str, commit: &'static str, branch: &'static str) -> Self {
+    pub fn new(
+        version: &'static str,
+        commit: &'static str,
+        branch: &'static str,
+        service_name: &'static str,
+    ) -> Self {
         Self {
             version,
             commit,
             branch,
+            service_name,
         }
     }
 
@@ -31,6 +37,7 @@ impl BuildInfoLabels {
             (COMMIT_KEY, self.commit),
             (VERSION_KEY, self.version),
             (BRANCH_KEY, self.branch),
+            (SERVICE_NAME_KEY, self.service_name),
         ]
     }
 }
@@ -43,6 +50,7 @@ impl BuildInfoLabels {
 pub struct CounterLabels {
     pub(crate) function: &'static str,
     pub(crate) module: &'static str,
+    pub(crate) service_name: &'static str,
     pub(crate) caller: &'static str,
     pub(crate) result: Option<ResultLabel>,
     pub(crate) ok: Option<&'static str>,
@@ -80,6 +88,7 @@ impl CounterLabels {
     pub fn new(
         function: &'static str,
         module: &'static str,
+        service_name: &'static str,
         caller: &'static str,
         result: Option<ResultAndReturnTypeLabels>,
         objective: Option<Objective>,
@@ -105,6 +114,7 @@ impl CounterLabels {
         Self {
             function,
             module,
+            service_name,
             caller,
             objective_name,
             objective_percentile,
@@ -118,6 +128,7 @@ impl CounterLabels {
         let mut labels = vec![
             (FUNCTION_KEY, self.function),
             (MODULE_KEY, self.module),
+            (SERVICE_NAME_KEY, self.service_name),
             (CALLER_KEY, self.caller),
         ];
         if let Some(result) = &self.result {
@@ -148,13 +159,19 @@ impl CounterLabels {
 pub struct HistogramLabels {
     pub function: &'static str,
     pub module: &'static str,
+    pub service_name: &'static str,
     pub objective_name: Option<&'static str>,
     pub objective_percentile: Option<ObjectivePercentile>,
     pub objective_latency_threshold: Option<ObjectiveLatency>,
 }
 
 impl HistogramLabels {
-    pub fn new(function: &'static str, module: &'static str, objective: Option<Objective>) -> Self {
+    pub fn new(
+        function: &'static str,
+        module: &'static str,
+        service_name: &'static str,
+        objective: Option<Objective>,
+    ) -> Self {
         let (objective_name, objective_percentile, objective_latency_threshold) =
             if let Some(objective) = objective {
                 if let Some((latency, percentile)) = objective.latency {
@@ -169,6 +186,7 @@ impl HistogramLabels {
         Self {
             function,
             module,
+            service_name,
             objective_name,
             objective_percentile,
             objective_latency_threshold,
@@ -203,11 +221,16 @@ impl HistogramLabels {
 pub struct GaugeLabels {
     pub function: &'static str,
     pub module: &'static str,
+    pub service_name: &'static str,
 }
 
 impl GaugeLabels {
-    pub fn to_array(&self) -> [Label; 2] {
-        [(FUNCTION_KEY, self.function), (MODULE_KEY, self.module)]
+    pub fn to_array(&self) -> Vec<Label> {
+        vec![
+            (FUNCTION_KEY, self.function),
+            (MODULE_KEY, self.module),
+            (SERVICE_NAME_KEY, self.service_name),
+        ]
     }
 }
 
@@ -222,24 +245,6 @@ impl GaugeLabels {
 // https://users.rust-lang.org/t/how-to-check-types-within-macro/33803/5
 // and this answer explains why it works:
 // https://users.rust-lang.org/t/how-to-check-types-within-macro/33803/8
-
-pub enum LabelArray {
-    Three([Label; 3]),
-    Four([Label; 4]),
-    Five([Label; 5]),
-}
-
-impl Deref for LabelArray {
-    type Target = [Label];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            LabelArray::Three(l) => l,
-            LabelArray::Four(l) => l,
-            LabelArray::Five(l) => l,
-        }
-    }
-}
 
 /// A trait to override the inferred label for the "result" of a function call.
 pub trait GetLabels {

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -210,11 +210,13 @@ pub(crate) const HISTOGRAM_BUCKETS: [f64; 14] = [
 #[doc(hidden)]
 pub mod __private {
     use crate::task_local::LocalKey;
+    use once_cell::sync::OnceCell;
     use std::{cell::RefCell, thread_local};
 
     pub use crate::constants::*;
     pub use crate::labels::*;
     pub use crate::tracker::{AutometricsTracker, TrackMetrics};
+    pub use spez::spez;
 
     /// Task-local value used for tracking which function called the current function
     pub static CALLER: LocalKey<&'static str> = {
@@ -229,5 +231,16 @@ pub mod __private {
         LocalKey { inner: CALLER_KEY }
     };
 
-    pub use spez::spez;
+    /// Load the service name from one of the following runtime environment variables:
+    /// - `AUTOMETRICS_SERVICE_NAME`
+    /// - `OTEL_SERVICE_NAME`
+    /// Or, fall back to the name of the cargo package defined in the `Cargo.toml` file.
+    pub fn service_name(cargo_pkg_name: &'static str) -> &'static str {
+        static SERVICE_NAME: OnceCell<String> = OnceCell::new();
+        SERVICE_NAME.get_or_init(|| {
+            std::env::var("AUTOMETRICS_SERVICE_NAME")
+                .or_else(|_| std::env::var("OTEL_SERVICE_NAME"))
+                .unwrap_or(cargo_pkg_name.to_string())
+        })
+    }
 }

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -243,7 +243,7 @@ pub mod __private {
         SERVICE_NAME.get_or_init(|| {
             std::env::var("AUTOMETRICS_SERVICE_NAME")
                 .or_else(|_| std::env::var("OTEL_SERVICE_NAME"))
-                .unwrap_or(cargo_pkg_name.to_string())
+                .unwrap_or_else(|| cargo_pkg_name.to_string())
         })
     }
 }

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -236,6 +236,9 @@ pub mod __private {
     /// - `OTEL_SERVICE_NAME`
     /// Or, fall back to the name of the cargo package defined in the `Cargo.toml` file.
     pub fn service_name(cargo_pkg_name: &'static str) -> &'static str {
+        // Note that we are using a OnceCell here because we want the label value to
+        // be available as a &'static str. This allows us to load the value from the
+        // environment variables once at startup while still accessing it as a &'static str
         static SERVICE_NAME: OnceCell<String> = OnceCell::new();
         SERVICE_NAME.get_or_init(|| {
             std::env::var("AUTOMETRICS_SERVICE_NAME")

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -243,7 +243,7 @@ pub mod __private {
         SERVICE_NAME.get_or_init(|| {
             std::env::var("AUTOMETRICS_SERVICE_NAME")
                 .or_else(|_| std::env::var("OTEL_SERVICE_NAME"))
-                .unwrap_or_else(|| cargo_pkg_name.to_string())
+                .unwrap_or_else(|_| cargo_pkg_name.to_string())
         })
     }
 }

--- a/autometrics/src/tracker/prometheus.rs
+++ b/autometrics/src/tracker/prometheus.rs
@@ -17,6 +17,7 @@ static COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
         &[
             FUNCTION_KEY,
             MODULE_KEY,
+            SERVICE_NAME_KEY_PROMETHEUS,
             CALLER_KEY,
             RESULT_KEY,
             OK_KEY,
@@ -42,6 +43,7 @@ static HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
         &[
             FUNCTION_KEY,
             MODULE_KEY,
+            SERVICE_NAME_KEY_PROMETHEUS,
             OBJECTIVE_NAME_PROMETHEUS,
             OBJECTIVE_PERCENTILE_PROMETHEUS,
             OBJECTIVE_LATENCY_THRESHOLD_PROMETHEUS
@@ -53,7 +55,7 @@ static GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         GAUGE_NAME_PROMETHEUS,
         GAUGE_DESCRIPTION,
-        &[FUNCTION_KEY, MODULE_KEY]
+        &[FUNCTION_KEY, MODULE_KEY, SERVICE_NAME_KEY_PROMETHEUS]
     )
     .expect("Failed to register function_calls_concurrent gauge")
 });
@@ -74,7 +76,11 @@ pub struct PrometheusTracker {
 impl TrackMetrics for PrometheusTracker {
     fn start(gauge_labels: Option<&GaugeLabels>) -> Self {
         let gauge = if let Some(gauge_labels) = gauge_labels {
-            let gauge = GAUGE.with_label_values(&[gauge_labels.function, gauge_labels.module]);
+            let gauge = GAUGE.with_label_values(&[
+                gauge_labels.function,
+                gauge_labels.module,
+                gauge_labels.service_name,
+            ]);
             gauge.inc();
             Some(gauge)
         } else {
@@ -96,6 +102,7 @@ impl TrackMetrics for PrometheusTracker {
                 &[
                     counter_labels.function,
                     counter_labels.module,
+                    counter_labels.service_name,
                     counter_labels.caller,
                     match counter_labels.result {
                         Some(ResultLabel::Ok) => OK_KEY,
@@ -118,6 +125,7 @@ impl TrackMetrics for PrometheusTracker {
             .with_label_values(&[
                 histogram_labels.function,
                 histogram_labels.module,
+                histogram_labels.service_name,
                 histogram_labels.objective_name.unwrap_or_default(),
                 histogram_labels
                     .objective_percentile

--- a/autometrics/src/tracker/prometheus.rs
+++ b/autometrics/src/tracker/prometheus.rs
@@ -63,7 +63,12 @@ static BUILD_INFO: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         BUILD_INFO_NAME,
         BUILD_INFO_DESCRIPTION,
-        &[COMMIT_KEY, VERSION_KEY, BRANCH_KEY]
+        &[
+            COMMIT_KEY,
+            VERSION_KEY,
+            BRANCH_KEY,
+            SERVICE_NAME_KEY_PROMETHEUS
+        ]
     )
     .expect("Failed to register build_info counter")
 });
@@ -152,6 +157,7 @@ impl TrackMetrics for PrometheusTracker {
                     build_info_labels.commit,
                     build_info_labels.version,
                     build_info_labels.branch,
+                    build_info_labels.service_name,
                 ])
                 .set(1);
         });

--- a/autometrics/tests/integration_test.rs
+++ b/autometrics/tests/integration_test.rs
@@ -19,6 +19,7 @@ fn single_function() {
             || line.starts_with("function_calls_count_total{"))
             && line.contains(r#"function="hello_world""#)
             && line.contains(r#"module="integration_test""#)
+            && line.contains(r#"service_name="autometrics""#)
             && line.ends_with("} 2")
     }));
     assert!(metrics
@@ -26,6 +27,7 @@ fn single_function() {
         .any(|line| line.starts_with("function_calls_duration_bucket{")
             && line.contains(r#"function="hello_world""#)
             && line.contains(r#"module="integration_test""#)
+            && line.contains(r#"service_name="autometrics""#)
             && line.ends_with("} 2")));
 }
 
@@ -190,5 +192,6 @@ fn build_info() {
         && line.contains(r#"branch="""#)
         && line.contains(r#"commit="""#)
         && line.contains(&format!("version=\"{}\"", env!("CARGO_PKG_VERSION")))
+        && line.contains(r#"service_name="autometrics""#)
         && line.ends_with("} 1")));
 }


### PR DESCRIPTION
Currently, this only supports loading the `service.name` from environment variables.

For the moment, I opted not to allow setting the `service.name` label by passing a parameter to the `autometrics` macro. It seems like a footgun to allow you to set different values for different metrics in the same service.

It might be nice to have a way to set the `service.name` using some initialization function, but we don't have a global initialization function yet for the Rust implementation. We could add it just for this purpose, but it seems like we could also wait until someone comes with a request along these lines. Also, it might be slightly confusing to have separate `init` functions for `autometrics` as well as `autometrics::prometheus_exporter`.

I'm curious what others think. cc @akesling
