### PR TITLE
Initialize counters to zero in debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Basic benchmarking
+- Function counters are initialized to zero in debug builds. This exposes details of
+  instrumented functions to Prometheus and visualization tools built on top of it,
+  before the functions have been called.
 
 ### Changed
 

--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -185,7 +185,7 @@ fn instrument_function(args: &AutometricsArgs, item: ItemFn) -> Result<TokenStre
                     name: #function_name,
                     module: module_path!(),
                     objective: #objective,
-                    service_name: #service_name,
+                    cargo_pkg_name: env!("CARGO_PKG_NAME"),
                 };
             }
         }

--- a/autometrics-macros/src/lib.rs
+++ b/autometrics-macros/src/lib.rs
@@ -158,6 +158,27 @@ fn instrument_function(args: &AutometricsArgs, item: ItemFn) -> Result<TokenStre
         quote! { None }
     };
 
+    // This is a little nuts.
+    // In debug mode, we're using the `linkme` crate to collect all the function descriptions into a static slice.
+    // We're then using that to start all the function counters at zero, even before the function is called.
+    let collect_function_descriptions = if cfg!(debug_assertions) {
+        quote! {
+            {
+                use autometrics::__private::{linkme::distributed_slice, FUNCTION_DESCRIPTIONS, FunctionDescription};
+                #[distributed_slice(FUNCTION_DESCRIPTIONS)]
+                // Point the distributed_slice macro to the linkme crate re-exported from autometrics
+                #[linkme(crate = autometrics::__private::linkme)]
+                static FUNCTION_DESCRIPTION: FunctionDescription = FunctionDescription {
+                    name: #function_name,
+                    module: module_path!(),
+                    objective: #objective,
+                };
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     Ok(quote! {
         #(#attrs)*
 
@@ -165,6 +186,8 @@ fn instrument_function(args: &AutometricsArgs, item: ItemFn) -> Result<TokenStre
         #[doc=#metrics_docs]
 
         #vis #sig {
+            #collect_function_descriptions
+
             let __autometrics_tracker = {
                 use autometrics::__private::{AutometricsTracker, BuildInfoLabels, TrackMetrics};
                 AutometricsTracker::set_build_info(&BuildInfoLabels::new(

--- a/autometrics/Cargo.toml
+++ b/autometrics/Cargo.toml
@@ -44,8 +44,9 @@ custom-objective-latency = []
 
 [dependencies]
 autometrics-macros = { workspace = true }
-spez = "0.1.2"
+linkme = "0.3"
 once_cell = "1.17"
+spez = "0.1.2"
 
 # Used for opentelemetry feature
 opentelemetry_api = { version = "0.19.0", default-features = false, optional = true }

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -252,7 +252,7 @@ pub mod __private {
         pub name: &'static str,
         pub module: &'static str,
         pub objective: Option<Objective>,
-        pub service_name: &'static str,
+        pub cargo_pkg_name: &'static str,
     }
 
     #[cfg(debug_assertions)]
@@ -269,7 +269,7 @@ pub mod __private {
             CounterLabels {
                 function: function.name,
                 module: function.module,
-                service_name: function.service_name,
+                service_name: service_name(function.cargo_pkg_name),
                 caller: "",
                 result: Some(ResultLabel::Ok),
                 ok: None,

--- a/autometrics/src/lib.rs
+++ b/autometrics/src/lib.rs
@@ -209,6 +209,8 @@ pub(crate) const HISTOGRAM_BUCKETS: [f64; 14] = [
 // so you don't get any autocompletion or type checking.
 #[doc(hidden)]
 pub mod __private {
+    #[cfg(debug_assertions)]
+    use crate::objectives::Objective;
     use crate::task_local::LocalKey;
     use std::{cell::RefCell, thread_local};
 
@@ -230,4 +232,49 @@ pub mod __private {
     };
 
     pub use spez::spez;
+
+    // Re-export linkme so that it can be used by the macro-generated code
+    #[cfg(debug_assertions)]
+    pub mod linkme {
+        pub use linkme::*;
+    }
+
+    /// In debug mode, we use linkme to collect all the function descriptions
+    /// so that we can initialize the counters to zero.
+    /// This exposes the details of instrumented functions to Prometheus
+    /// before they are called for the first time.
+    #[cfg(debug_assertions)]
+    #[linkme::distributed_slice]
+    pub static FUNCTION_DESCRIPTIONS: [FunctionDescription] = [..];
+
+    #[cfg(debug_assertions)]
+    pub struct FunctionDescription {
+        pub name: &'static str,
+        pub module: &'static str,
+        pub objective: Option<Objective>,
+    }
+
+    #[cfg(debug_assertions)]
+    impl From<&FunctionDescription> for CounterLabels {
+        fn from(function: &FunctionDescription) -> Self {
+            let (objective_name, objective_percentile) = match &function.objective {
+                Some(Objective {
+                    name,
+                    success_rate: Some(percentile),
+                    ..
+                }) => (Some(*name), Some(*percentile)),
+                _ => (None, None),
+            };
+            CounterLabels {
+                function: function.name,
+                module: function.module,
+                caller: "",
+                result: Some(ResultLabel::Ok),
+                ok: None,
+                error: None,
+                objective_name,
+                objective_percentile,
+            }
+        }
+    }
 }

--- a/autometrics/src/objectives.rs
+++ b/autometrics/src/objectives.rs
@@ -122,7 +122,8 @@ impl Objective {
 }
 
 /// The percentage of requests that must meet the given criteria (success rate or latency).
-#[cfg_attr(prometheus_client, derive(Clone, Debug, PartialEq, Eq, Hash))]
+#[cfg_attr(any(prometheus_client, debug_assertions), derive(Clone, Copy))]
+#[cfg_attr(prometheus_client, derive(Debug, PartialEq, Eq, Hash))]
 #[non_exhaustive]
 pub enum ObjectivePercentile {
     /// 90%

--- a/autometrics/src/tracker/metrics.rs
+++ b/autometrics/src/tracker/metrics.rs
@@ -1,3 +1,5 @@
+#[cfg(debug_assertions)]
+use crate::__private::FunctionDescription;
 use crate::constants::*;
 use crate::labels::{BuildInfoLabels, CounterLabels, GaugeLabels, HistogramLabels};
 use crate::tracker::TrackMetrics;
@@ -55,5 +57,13 @@ impl TrackMetrics for MetricsTracker {
         SET_BUILD_INFO.call_once(|| {
             register_gauge!(BUILD_INFO_NAME, &build_info_labels.to_vec()).set(1.0);
         });
+    }
+
+    #[cfg(debug_assertions)]
+    fn intitialize_metrics(function_descriptions: &[FunctionDescription]) {
+        for function in function_descriptions {
+            let labels = &CounterLabels::from(function).to_vec();
+            register_counter!(COUNTER_NAME, labels).increment(0);
+        }
     }
 }

--- a/autometrics/src/tracker/mod.rs
+++ b/autometrics/src/tracker/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(debug_assertions)]
+use crate::__private::FunctionDescription;
 use crate::labels::{BuildInfoLabels, CounterLabels, GaugeLabels, HistogramLabels};
 
 #[cfg(metrics)]
@@ -32,6 +34,8 @@ pub trait TrackMetrics {
     fn set_build_info(build_info_labels: &BuildInfoLabels);
     fn start(gauge_labels: Option<&GaugeLabels>) -> Self;
     fn finish(self, counter_labels: &CounterLabels, histogram_labels: &HistogramLabels);
+    #[cfg(debug_assertions)]
+    fn intitialize_metrics(function_descriptions: &[FunctionDescription]);
 }
 
 pub struct AutometricsTracker {
@@ -86,5 +90,17 @@ impl TrackMetrics for AutometricsTracker {
         #[cfg(prometheus_client)]
         self.prometheus_client_tracker
             .finish(counter_labels, histogram_labels);
+    }
+
+    #[cfg(debug_assertions)]
+    fn intitialize_metrics(function_descriptions: &[FunctionDescription]) {
+        #[cfg(metrics)]
+        MetricsTracker::intitialize_metrics(function_descriptions);
+        #[cfg(opentelemetry)]
+        OpenTelemetryTracker::intitialize_metrics(function_descriptions);
+        #[cfg(prometheus)]
+        PrometheusTracker::intitialize_metrics(function_descriptions);
+        #[cfg(prometheus_client)]
+        PrometheusClientTracker::intitialize_metrics(function_descriptions);
     }
 }

--- a/autometrics/src/tracker/opentelemetry.rs
+++ b/autometrics/src/tracker/opentelemetry.rs
@@ -1,3 +1,5 @@
+#[cfg(debug_assertions)]
+use crate::__private::FunctionDescription;
 use crate::labels::{BuildInfoLabels, CounterLabels, GaugeLabels, HistogramLabels, Label};
 use crate::{constants::*, tracker::TrackMetrics};
 use once_cell::sync::Lazy;
@@ -78,6 +80,14 @@ impl TrackMetrics for OpenTelemetryTracker {
                 .init();
             build_info.add(&Context::current(), 1.0, &build_info_labels);
         });
+    }
+
+    #[cfg(debug_assertions)]
+    fn intitialize_metrics(function_descriptions: &[FunctionDescription]) {
+        for function in function_descriptions {
+            let labels = &to_key_values(CounterLabels::from(function).to_vec());
+            COUNTER.add(&Context::current(), 0, labels);
+        }
     }
 }
 

--- a/autometrics/src/tracker/prometheus_client.rs
+++ b/autometrics/src/tracker/prometheus_client.rs
@@ -1,4 +1,6 @@
 use super::TrackMetrics;
+#[cfg(debug_assertions)]
+use crate::__private::FunctionDescription;
 #[cfg(exemplars)]
 use crate::exemplars::get_exemplar;
 use crate::labels::{BuildInfoLabels, CounterLabels, GaugeLabels, HistogramLabels};
@@ -104,6 +106,20 @@ impl TrackMetrics for PrometheusClientTracker {
 
         if let Some(gauge_labels) = &self.gauge_labels {
             METRICS.gauge.get_or_create(gauge_labels).dec();
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    fn intitialize_metrics(function_descriptions: &[FunctionDescription]) {
+        for function in function_descriptions {
+            METRICS
+                .counter
+                .get_or_create(&CounterLabels::from(function))
+                .inc_by(
+                    0,
+                    #[cfg(exemplars)]
+                    None,
+                );
         }
     }
 }

--- a/autometrics/tests/integration_test.rs
+++ b/autometrics/tests/integration_test.rs
@@ -192,3 +192,19 @@ fn build_info() {
         && line.contains(&format!("version=\"{}\"", env!("CARGO_PKG_VERSION")))
         && line.ends_with("} 1")));
 }
+
+#[cfg(debug_assertions)]
+#[test]
+fn zero_metrics() {
+    prometheus_exporter::init();
+
+    #[autometrics]
+    fn zero_metrics_fn() {}
+
+    // Note that we are not calling the function, but it should still be registered
+
+    let metrics = prometheus_exporter::encode_to_string().unwrap();
+    assert!(metrics
+        .lines()
+        .any(|line| line.contains(r#"function="zero_metrics_fn""#) && line.ends_with("} 0")));
+}


### PR DESCRIPTION
This uses the [`linkme::distributed_slice`](https://docs.rs/linkme/latest/linkme/#distributed-slice) macro to collect all of the function details into a slice at compile/link time. Then, when the `prometheus_exporter::init` function is called, all of the function counters are set to zero.

If we had a general autometrics initialization function (#117), we might want to move the counter initialization into there.

Alternatively, if we wanted to ensure that this is run without having an explicit initialization function, I think we _could_ use [`ctor`](https://crates.io/crates/ctor) to initialize the counters.

Resolves https://github.com/autometrics-dev/autometrics-rs/issues/70