### PR TITLE
Include crate version in backend feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,25 +19,25 @@ jobs:
 
       # Lint
       # Note: GitHub hosted runners using the latest stable version of Rust have Clippy pre-installed.
-      - run: cargo clippy --features=metrics,prometheus-exporter
-      - run: cargo clippy --features=prometheus
-      - run: cargo clippy --features=prometheus-client
-      - run: cargo clippy --features=opentelemetry
+      - run: cargo clippy --features=metrics-0_21,prometheus-exporter
+      - run: cargo clippy --features=prometheus-0_13
+      - run: cargo clippy --features=prometheus-client-0_21
+      - run: cargo clippy --features=opentelemetry-0_19
 
       # Run the tests with each of the different metrics libraries
       - run: cargo test --features=prometheus-exporter
-      - run: cargo test --features=prometheus-exporter,metrics
-      - run: cargo test --features=prometheus-exporter,prometheus
-      - run: cargo test --features=prometheus-exporter,prometheus-client,exemplars-tracing
-      - run: cargo test --features=prometheus-exporter,prometheus-client,exemplars-tracing-opentelemetry
+      - run: cargo test --features=prometheus-exporter,metrics-0_21
+      - run: cargo test --features=prometheus-exporter,prometheus-0_13
+      - run: cargo test --features=prometheus-exporter,prometheus-client-0_21,exemplars-tracing
+      - run: cargo test --features=prometheus-exporter,prometheus-client-0_21,exemplars-tracing-opentelemetry
       # The tests using opentelemetry are currently failing because of this issue:
       # https://github.com/open-telemetry/opentelemetry-rust/issues/1070
       # We should remove the continue-on-error once that is fixed
-      - run: cargo test --features=prometheus-exporter,opentelemetry
+      - run: cargo test --features=prometheus-exporter,opentelemetry-0_19
         continue-on-error: true
 
       # Build the crate using the other optional features
-      - run: cargo build --features=metrics,custom-objective-percentile,custom-objective-latency
+      - run: cargo build --features=metrics-0_21,custom-objective-percentile,custom-objective-latency
 
       # Compile the examples
       - run: cargo build --package example-actix-web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
--
+- `metrics` feature flag (replaced with `metrics-0_21`)
+- `opentelemetry` feature flag (replaced with `opentelemetry-0_19`)
+- `prometheus` feature flag (replaced with `prometheus-0_13`)
+- `prometheus-client` feature flag (replaced with `prometheus-client-0_21`)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ https://github.com/autometrics-dev/autometrics-rs/assets/3262610/966ed140-1d6c-4
 
       <br />
 
-      [Configure `autometrics`](https://docs.rs/autometrics/latest/autometrics/#metrics-libraries) to use the same underlying metrics library you use with the appropriate feature flag: `opentelemetry`, `prometheus`, `prometheus-client`, or `metrics`.
+      [Configure `autometrics`](https://docs.rs/autometrics/latest/autometrics/#metrics-libraries) to use the same underlying metrics library you use with the feature flag corresponding to the crate and version you are using.
 
       ```toml
       [dependencies]
       autometrics = {
         version = "*",
-        features = ["prometheus"],
+        features = ["opentelemetry-0_19"],
         default-features = false
       }
       ```
@@ -203,10 +203,10 @@ To see autometrics in action:
 ## Benchmarks
 
 Using each of the following metrics libraries, tracking metrics with the `autometrics` macro adds approximately:
-- `prometheus`: 140-150 nanoseconds
-- `prometheus-client`: 150-250 nanoseconds
-- `metrics`: 550-650 nanoseconds
-- `opentelemetry`: 550-750 nanoseconds
+- `prometheus-0_13`: 140-150 nanoseconds
+- `prometheus-client-0_21`: 150-250 nanoseconds
+- `metrics-0_21`: 550-650 nanoseconds
+- `opentelemetry-0_19`: 550-750 nanoseconds
 
 These were calculated on a 2021 MacBook Pro with the M1 Max chip and 64 GB of RAM.
 

--- a/autometrics/Cargo.toml
+++ b/autometrics/Cargo.toml
@@ -14,6 +14,12 @@ readme = "README.md"
 
 [features]
 # Metrics backends
+metrics-0_21 = ["dep:metrics"]
+opentelemetry-0_19 = ["opentelemetry_api/metrics"]
+prometheus-0_13 = ["dep:prometheus"]
+prometheus-client-0_21 = ["dep:prometheus-client"]
+
+# Deprecated feature flag names for metrics backends
 metrics = ["dep:metrics"]
 opentelemetry = ["opentelemetry_api/metrics"]
 prometheus = ["dep:prometheus"]

--- a/autometrics/build.rs
+++ b/autometrics/build.rs
@@ -3,12 +3,21 @@ use cfg_aliases::cfg_aliases;
 pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
+    #[cfg(feature = "metrics")]
+    println!("cargo:warning=The `metrics` feature is deprecated and will be removed in the next version. Please use `metrics-0_21` instead.");
+    #[cfg(feature = "opentelemetry")]
+    println!("cargo:warning=The `opentelemetry` feature is deprecated and will be removed in the next version. Please use `opentelemetry-0_19` instead.");
+    #[cfg(feature = "prometheus")]
+    println!("cargo:warning=The `prometheus` feature is deprecated and will be removed in the next version. Please use `prometheus-0_13` instead.");
+    #[cfg(feature = "prometheus-client")]
+    println!("cargo:warning=The `prometheus-client` feature is deprecated and will be removed in the next version. Please use `prometheus-client-0_21` instead.");
+
     cfg_aliases! {
       // Backends
-      metrics: { feature = "metrics" },
-      opentelemetry: { feature = "opentelemetry" },
-      prometheus: { feature = "prometheus" },
-      prometheus_client_feature: { feature = "prometheus-client" },
+      metrics: { any(feature = "metrics", feature = "metrics-0_21") },
+      opentelemetry: { any(feature = "opentelemetry", feature = "opentelemetry-0_19") },
+      prometheus: { any(feature = "prometheus", feature = "prometheus-0_13") },
+      prometheus_client_feature: { any(feature = "prometheus-client", feature = "prometheus-client-0_21") },
       default_backend: { all(
         prometheus_exporter,
         not(any(metrics, opentelemetry, prometheus, prometheus_client_feature))

--- a/autometrics/src/README.md
+++ b/autometrics/src/README.md
@@ -128,10 +128,10 @@ The service name is loaded from the following environment variables, in this ord
 >
 > If you are **not** using the `prometheus-exporter`, you must ensure that you are using the exact same version of the metrics library as `autometrics` (and it must come from `crates.io` rather than git or another source). If not, the autometrics metrics will not appear in your exported metrics.
 
-- `opentelemetry`  - use the [opentelemetry](https://crates.io/crates/opentelemetry) crate for producing metrics.
-- `metrics` - use the [metrics](https://crates.io/crates/metrics) crate for producing metrics
-- `prometheus` - use the [prometheus](https://crates.io/crates/prometheus) crate for producing metrics
-- `prometheus-client` - use the official [prometheus-client](https://crates.io/crates/prometheus-client) crate for producing metrics
+- `opentelemetry-0_19`  - use the [opentelemetry](https://crates.io/crates/opentelemetry) crate for producing metrics.
+- `metrics-0_21` - use the [metrics](https://crates.io/crates/metrics) crate for producing metrics
+- `prometheus-0_13` - use the [prometheus](https://crates.io/crates/prometheus) crate for producing metrics
+- `prometheus-client-0_21` - use the official [prometheus-client](https://crates.io/crates/prometheus-client) crate for producing metrics
 
 #### Exemplars (for integrating metrics with traces)
 

--- a/examples/actix-web/Cargo.toml
+++ b/examples/actix-web/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 actix-web = "4.3.1"
-autometrics = { path = "../../autometrics", features = ["prometheus", "prometheus-exporter"] }
+autometrics = { path = "../../autometrics", features = ["prometheus-exporter"] }
 autometrics-example-util = { path = "../util" }
 rand = "0.8.5"
 reqwest = "0.11"

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-autometrics = { path = "../../autometrics", features = ["prometheus", "prometheus-exporter"] }
+autometrics = { path = "../../autometrics", features = ["prometheus-exporter"] }
 autometrics-example-util = { path = "../util" }
 axum = { version = "0.6", features = ["json"] }
 rand = "0.8"

--- a/examples/custom-metrics/Cargo.toml
+++ b/examples/custom-metrics/Cargo.toml
@@ -12,7 +12,7 @@ prometheus = ["autometrics/prometheus", "dep:prometheus", "once_cell"]
 
 [dependencies]
 autometrics = { path = "../../autometrics", features = ["prometheus-exporter"] }
-metrics = { version = "0.20", optional = true }
+metrics = { version = "0.21.1", optional = true }
 once_cell = { version = "1.17", optional = true }
-opentelemetry = { version = "0.18", features = ["metrics"], optional = true }
+opentelemetry = { version = "0.19.0", features = ["metrics"], optional = true }
 prometheus = { version = "0.13", optional = true }

--- a/examples/custom-metrics/README.md
+++ b/examples/custom-metrics/README.md
@@ -4,20 +4,20 @@ This example demonstrates how you can collect custom metrics in addition to the 
 
 ## Running the example
 
-### Using the `opentelemetry` crate (default)
+### Using the `opentelemetry` crate
 
 ```shell
-cargo run -p example-custom-metrics --features=opentelemetry
+cargo run -p example-custom-metrics --features=opentelemetry-0_19
 ```
 
 ### Using the `metrics` crate
 
 ```shell
-cargo run -p example-custom-metrics --features=metrics
+cargo run -p example-custom-metrics --features=metrics-0_21
 ```
 
 ### Using the `prometheus` crate
 
 ```shell
-cargo run -p example-custom-metrics --features=prometheus
+cargo run -p example-custom-metrics --features=prometheus-0_13
 ```

--- a/examples/exemplars-tracing-opentelemetry/Cargo.toml
+++ b/examples/exemplars-tracing-opentelemetry/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 autometrics = { path = "../../autometrics", features = [
-  "prometheus-client",
+  "prometheus-client-0_21",
   "prometheus-exporter",
   "exemplars-tracing-opentelemetry"
   ] }

--- a/examples/exemplars-tracing/Cargo.toml
+++ b/examples/exemplars-tracing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 autometrics = { path = "../../autometrics", features = [
-  "prometheus-client",
+  "prometheus-client-0_21",
   "prometheus-exporter",
   "exemplars-tracing"
   ] }

--- a/examples/full-api/Cargo.toml
+++ b/examples/full-api/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-autometrics = { path = "../../autometrics", features = ["prometheus", "prometheus-exporter"] }
+autometrics = { path = "../../autometrics", features = ["prometheus-exporter"] }
 autometrics-example-util = { path = "../util" }
 axum = { version = "0.6", features = ["json"] }
 rand = "0.8"

--- a/examples/opentelemetry-push/Cargo.toml
+++ b/examples/opentelemetry-push/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-autometrics = { path = "../../autometrics", features = ["opentelemetry"] }
+autometrics = { path = "../../autometrics", features = ["opentelemetry-0_19"] }
 autometrics-example-util = { path = "../util" }
 # Note that the version of the opentelemetry crate MUST match
 # the version used by autometrics


### PR DESCRIPTION
This addresses two issues:
1. If you want to use autometrics with a specific backend to add custom metrics or export them in your own way, the version the underlying crate must exactly match or the metrics will not appear. This is because of the use of global statics and the fact that Cargo will include multiple versions of a crate, which will have separate statics. This was the issue discovered in https://github.com/autometrics-dev/autometrics-rs/issues/91#issuecomment-1554377495
2. It would be nice to declare a 1.0 of Autometrics soon-ish, but we depend on crates that are <1.0. We can hopefully avoid needing to make technically breaking changes when the underlying metrics libraries release new versions by adding support for the new versions using different feature flags while keeping the old ones.

Resolves https://github.com/autometrics-dev/autometrics-rs/issues/125
