### PR TITLE
Fix a minor typo

### DIFF
--- a/examples/full-api/src/main.rs
+++ b/examples/full-api/src/main.rs
@@ -16,7 +16,7 @@ mod util;
 async fn main() {
     // Run Prometheus and generate random traffic for the app
     // (You would not actually do this in production, but it makes it easier to see the example in action)
-    let _promehtheus = run_prometheus(false);
+    let _prometheus = run_prometheus(false);
     tokio::spawn(generate_random_traffic());
 
     // Set up the exporter to collect metrics


### PR DESCRIPTION
Since this isn't ever used, this doesn't really affect anything, but just for clarity, fix the typo of 'prometheus' in the full-api example.