### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with: 
+          toolchain: stable
+          components: clippy
       - uses: Swatinem/rust-cache@v2
 
       # Lint

--- a/autometrics/tests/compilation/error_locus/fail/report_original_line.stderr
+++ b/autometrics/tests/compilation/error_locus/fail/report_original_line.stderr
@@ -6,5 +6,5 @@ error[E0596]: cannot borrow `contents` as mutable, as it is not declared as muta
    |
 help: consider changing this to be mutable
    |
-8  |     let mut contents: Vec<u32> = Vec::new();
+ 8 |     let mut contents: Vec<u32> = Vec::new();
    |         +++


### PR DESCRIPTION
The explicit `clippy` toolchain addition allows debugging the whole CI workflow with `act` (see https://github.com/nektos/act)

The indentation stuff is probably linked to rust 1.90 (though I didn't find the exact reason in changelog) but running with `act` allowed repro the issue while making me realize that stable rust had been updated
